### PR TITLE
Fix ordering detection in Select projections and add tests

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <Version>0.1.4</Version>
+    <Version>0.1.5</Version>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/src/EfOrderBy/OrderingDetector.cs
+++ b/src/EfOrderBy/OrderingDetector.cs
@@ -14,6 +14,16 @@
             return node;
         }
 
+        // Check if this is a Select - don't look for ordering inside its lambda
+        if (node.Method.DeclaringType == typeof(Queryable) &&
+            node.Method.Name == "Select")
+        {
+            // Visit the source (first argument) but skip the lambda (second argument)
+            // to avoid detecting ordering within Select(_ => new { ... _.Children.OrderBy(...) })
+            Visit(node.Arguments[0]);
+            return node;
+        }
+
         var method = node.Method;
         if ((method.DeclaringType == typeof(Queryable) || method.DeclaringType == typeof(Enumerable)) &&
             method.Name is

--- a/src/Tests/DefaultOrderByTests.SelectWithOrderByInProjection_AppliesDefaultOrderToParent.verified.txt
+++ b/src/Tests/DefaultOrderByTests.SelectWithOrderByInProjection_AppliesDefaultOrderToParent.verified.txt
@@ -1,0 +1,4 @@
+﻿SELECT [d].[Id], [d].[Name], [d].[DisplayOrder], [e].[Id], [e].[DepartmentId], [e].[HireDate], [e].[Name], [e].[Salary]
+FROM [Departments] AS [d]
+LEFT JOIN [Employees] AS [e] ON [d].[Id] = [e].[DepartmentId]
+ORDER BY [d].[DisplayOrder], [d].[Id], [e].[Id]

--- a/src/Tests/DefaultOrderByTests.SelectWithOrderByInProjection_AppliesDefaultOrderToParent_ResultsVerification.verified.txt
+++ b/src/Tests/DefaultOrderByTests.SelectWithOrderByInProjection_AppliesDefaultOrderToParent_ResultsVerification.verified.txt
@@ -1,0 +1,84 @@
+﻿{
+  target: [
+    {
+      Id: 1,
+      Name: Engineering,
+      DisplayOrder: 1,
+      Employees: [
+        {
+          Id: 1,
+          DepartmentId: 1,
+          Name: Alice,
+          HireDate: 2024-01-15,
+          Salary: 90000
+        },
+        {
+          Id: 2,
+          DepartmentId: 1,
+          Name: Bob,
+          HireDate: 2024-03-20,
+          Salary: 85000
+        },
+        {
+          Id: 3,
+          DepartmentId: 1,
+          Name: Charlie,
+          HireDate: 2023-06-10,
+          Salary: 95000
+        }
+      ]
+    },
+    {
+      Id: 2,
+      Name: Sales,
+      DisplayOrder: 2,
+      Employees: [
+        {
+          Id: 4,
+          DepartmentId: 2,
+          Name: Diana,
+          HireDate: 2024-02-05,
+          Salary: 70000
+        },
+        {
+          Id: 5,
+          DepartmentId: 2,
+          Name: Eve,
+          HireDate: 2023-11-01,
+          Salary: 72000
+        }
+      ]
+    },
+    {
+      Id: 3,
+      Name: HR,
+      DisplayOrder: 3,
+      Employees: [
+        {
+          Id: 6,
+          DepartmentId: 3,
+          Name: Frank,
+          HireDate: 2024-04-10,
+          Salary: 65000
+        }
+      ]
+    }
+  ],
+  sql: {
+    Text:
+select   d.Id,
+         d.Name,
+         d.DisplayOrder,
+         e.Id,
+         e.DepartmentId,
+         e.HireDate,
+         e.Name,
+         e.Salary
+from     Departments as d
+         left outer join
+         Employees as e
+         on d.Id = e.DepartmentId
+order by d.DisplayOrder, d.Id, e.Id,
+    HasTransaction: false
+  }
+}


### PR DESCRIPTION
Update OrderingDetector to skip detecting ordering inside Select projection lambdas, ensuring default ordering is still applied to parent queries. Add tests to verify correct SQL generation and runtime results when OrderBy is used within Select projections. Bump version to 0.1.5.