### PR TITLE
Create indexes in model-finalizing convention

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <Version>0.1.6</Version>
+    <Version>0.1.7</Version>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/src/EfOrderBy/Configuration.cs
+++ b/src/EfOrderBy/Configuration.cs
@@ -14,6 +14,8 @@ sealed class Configuration(Type elementType)
     /// </summary>
     internal List<string> PropertyNames { get; } = [];
 
+    internal string? CustomIndexName { get; set; }
+
     internal void AddClause(PropertyInfo propertyInfo, bool descending, bool isThenBy)
     {
         Clauses.Add(new(elementType, parameter, propertyInfo, descending, isThenBy));

--- a/src/EfOrderBy/OrderByBuilder.cs
+++ b/src/EfOrderBy/OrderByBuilder.cs
@@ -6,22 +6,17 @@ namespace EfOrderBy;
 public sealed class OrderByBuilder<TEntity>
     where TEntity : class
 {
-    const int MaxIndexNameLength = 128;
+    const int maxIndexNameLength = 128;
 
     Configuration configuration;
-    EntityTypeBuilder<TEntity> entityBuilder;
-    string? customIndexName;
 
     internal OrderByBuilder(EntityTypeBuilder<TEntity> builder, PropertyInfo propertyInfo, bool descending)
     {
-        entityBuilder = builder;
         configuration = new(typeof(TEntity));
         configuration.AddClause(propertyInfo, descending, isThenBy: false);
 
         // Store configuration in model annotation
         builder.Metadata.SetAnnotation(OrderByExtensions.AnnotationName, configuration);
-
-        UpdateIndex();
     }
 
     /// <summary>
@@ -31,7 +26,6 @@ public sealed class OrderByBuilder<TEntity>
     {
         var propertyInfo = GetPropertyInfo(property);
         configuration.AddClause(propertyInfo, descending: false, isThenBy: true);
-        UpdateIndex();
         return this;
     }
 
@@ -42,7 +36,6 @@ public sealed class OrderByBuilder<TEntity>
     {
         var propertyInfo = GetPropertyInfo(property);
         configuration.AddClause(propertyInfo, descending: true, isThenBy: true);
-        UpdateIndex();
         return this;
     }
 
@@ -57,43 +50,13 @@ public sealed class OrderByBuilder<TEntity>
             throw new ArgumentException("Index name cannot be null or whitespace.", nameof(indexName));
         }
 
-        if (indexName.Length > MaxIndexNameLength)
+        if (indexName.Length > maxIndexNameLength)
         {
-            throw new ArgumentException($"Index name '{indexName}' exceeds maximum length of {MaxIndexNameLength} characters.", nameof(indexName));
+            throw new ArgumentException($"Index name '{indexName}' exceeds maximum length of {maxIndexNameLength} characters.", nameof(indexName));
         }
 
-        customIndexName = indexName;
-        UpdateIndex();
+        configuration.CustomIndexName = indexName;
         return this;
-    }
-
-    /// <summary>
-    /// Creates or updates a composite index for all ordering properties.
-    /// </summary>
-    void UpdateIndex()
-    {
-        var indexName = customIndexName ?? $"IX_{typeof(TEntity).Name}_DefaultOrder";
-
-        if (indexName.Length > MaxIndexNameLength)
-        {
-            throw new InvalidOperationException(
-                $"The auto-generated index name '{indexName}' exceeds the maximum length of {MaxIndexNameLength} characters. " +
-                $"Use .WithIndexName() to specify a shorter custom index name.");
-        }
-
-        var entityType = entityBuilder.Metadata;
-
-        // Remove existing index with this name (if any) before creating the updated one
-        var existingIndex = entityType.GetIndexes()
-            .FirstOrDefault(i => i.GetDatabaseName() == indexName);
-        if (existingIndex != null)
-        {
-            entityType.RemoveIndex(existingIndex);
-        }
-
-        entityBuilder
-            .HasIndex(configuration.PropertyNames.ToArray())
-            .HasDatabaseName(indexName);
     }
 
     static PropertyInfo GetPropertyInfo<TProperty>(Expression<Func<TEntity, TProperty>> property)

--- a/src/EfOrderBy/UseDefaultOrderByConventionPlugin.cs
+++ b/src/EfOrderBy/UseDefaultOrderByConventionPlugin.cs
@@ -6,6 +6,7 @@ sealed class UseDefaultOrderByConventionPlugin : IConventionSetPlugin
     public ConventionSet ModifyConventions(ConventionSet conventionSet)
     {
         conventionSet.ModelInitializedConventions.Add(new UseDefaultOrderByConvention());
+        conventionSet.ModelFinalizingConventions.Add(new OrderByIndexConvention());
         return conventionSet;
     }
 }
@@ -17,4 +18,36 @@ sealed class UseDefaultOrderByConvention : IModelInitializedConvention
 {
     public void ProcessModelInitialized(IConventionModelBuilder modelBuilder, IConventionContext<IConventionModelBuilder> context) =>
         modelBuilder.HasAnnotation(OrderByExtensions.InterceptorRegisteredAnnotation, true);
+}
+
+/// <summary>
+/// Convention that creates database indexes for all configured default orderings during model finalization.
+/// </summary>
+sealed class OrderByIndexConvention : IModelFinalizingConvention
+{
+    const int maxIndexNameLength = 128;
+
+    public void ProcessModelFinalizing(IConventionModelBuilder modelBuilder, IConventionContext<IConventionModelBuilder> context)
+    {
+        foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
+        {
+            var annotation = entityType.FindAnnotation(OrderByExtensions.AnnotationName);
+            if (annotation?.Value is not Configuration config)
+            {
+                continue;
+            }
+
+            var indexName = config.CustomIndexName ?? $"IX_{entityType.ClrType.Name}_DefaultOrder";
+
+            if (indexName.Length > maxIndexNameLength)
+            {
+                throw new InvalidOperationException(
+                    $"The auto-generated index name '{indexName}' exceeds the maximum length of {maxIndexNameLength} characters. " +
+                    $"Use .WithIndexName() to specify a shorter custom index name.");
+            }
+
+            var indexBuilder = entityType.Builder.HasIndex(config.PropertyNames.ToList(), fromDataAnnotation: false);
+            indexBuilder?.HasDatabaseName(indexName, fromDataAnnotation: false);
+        }
+    }
 }

--- a/src/Tests/IndexNameTests.cs
+++ b/src/Tests/IndexNameTests.cs
@@ -84,7 +84,7 @@ public class IndexNameTests
         var index = entityType.GetIndexes().FirstOrDefault();
         Assert.That(index, Is.Not.Null);
         Assert.That(index?.GetDatabaseName(), Is.EqualTo("IX_Multi_Custom"));
-        Assert.That(index?.Properties.Select(p => p.Name), Is.EquivalentTo(new[] { "Category", "Priority" }));
+        Assert.That(index?.Properties.Select(p => p.Name), Is.EquivalentTo(["Category", "Priority"]));
     }
 }
 
@@ -138,7 +138,7 @@ class ContextWithTooLongCustomIndexName(DbContextOptions options)
         base.OnModelCreating(modelBuilder);
         modelBuilder.Entity<ShortEntity>()
             .OrderBy(_ => _.Name)
-            .WithIndexName(new string('X', 129)); // 129 characters exceeds limit
+            .WithIndexName(new('X', 129)); // 129 characters exceeds limit
     }
 }
 


### PR DESCRIPTION
Add OrderByIndexConvention to build database indexes for configured default orderings during model finalization and register it in UseDefaultOrderByConventionPlugin. Store a CustomIndexName on Configuration and move index name/length validation and index creation out of OrderByBuilder. Simplify OrderByBuilder by removing UpdateIndex and entityBuilder fields, and set configuration.CustomIndexName from WithIndexName. Adjust constant naming for maxIndexNameLength and update tests accordingly.