### PR TITLE
Detect conflicting default ordering across contexts

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <Version>0.3.1</Version>
+    <Version>0.3.2</Version>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/src/EfOrderBy/Configuration.cs
+++ b/src/EfOrderBy/Configuration.cs
@@ -8,7 +8,20 @@ sealed class Configuration(Type elementType)
     static readonly ConcurrentDictionary<Type, Configuration> cache = new();
 
     internal static void Cache(Type entityType, Configuration configuration)
-        => cache[entityType] = configuration;
+        => cache.AddOrUpdate(
+            entityType,
+            configuration,
+            (type, existing) =>
+            {
+                if (!existing.ClauseMetadataList.SequenceEqual(configuration.ClauseMetadataList))
+                {
+                    throw new InvalidOperationException(
+                        $"Conflicting default ordering configurations for entity type '{type.Name}'. " +
+                        $"When multiple DbContext types share the same entity, they must configure the same default ordering.");
+                }
+
+                return existing;
+            });
 
     internal static Configuration? TryGet(Type entityType)
         => cache.GetValueOrDefault(entityType);

--- a/src/Tests/DuplicateOrderByTests.cs
+++ b/src/Tests/DuplicateOrderByTests.cs
@@ -132,6 +132,20 @@ public class AnotherDuplicateTestEntity
     public string Value { get; set; } = "";
 }
 
+public class ThenByEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+    public int Priority { get; set; }
+}
+
+public class ThenByDescEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+    public int Priority { get; set; }
+}
+
 #endregion
 
 #region Test Contexts - Each with unique configuration
@@ -186,20 +200,20 @@ public class OrderByDescendingThenAscContext(DbContextOptions options) : DbConte
 
 public class OrderByWithThenByContext(DbContextOptions options) : DbContext(options)
 {
-    public DbSet<DuplicateTestEntity> Entities => Set<DuplicateTestEntity>();
+    public DbSet<ThenByEntity> Entities => Set<ThenByEntity>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder) =>
-        modelBuilder.Entity<DuplicateTestEntity>()
+        modelBuilder.Entity<ThenByEntity>()
             .OrderBy(_ => _.Name)
             .ThenBy(_ => _.Priority); // Correct usage
 }
 
 public class OrderByDescWithThenByDescContext(DbContextOptions options) : DbContext(options)
 {
-    public DbSet<DuplicateTestEntity> Entities => Set<DuplicateTestEntity>();
+    public DbSet<ThenByDescEntity> Entities => Set<ThenByDescEntity>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder) =>
-        modelBuilder.Entity<DuplicateTestEntity>()
+        modelBuilder.Entity<ThenByDescEntity>()
             .OrderByDescending(_ => _.Name)
             .ThenByDescending(_ => _.Priority); // Correct usage
 }

--- a/src/Tests/MigrationTests.cs
+++ b/src/Tests/MigrationTests.cs
@@ -105,4 +105,59 @@ public class MigrationTests
         Assert.That(designTimeModel.FindAnnotation("DefaultOrderBy:InterceptorRegistered"), Is.Null);
         Assert.That(designTimeModel.FindAnnotation("DefaultOrderBy:IndexCreationDisabled"), Is.Null);
     }
+
+    [Test]
+    public void ConflictingOrderingAcrossContexts_Throws()
+    {
+        // First context configures SharedEntity with OrderBy(Name)
+        var options1 = new DbContextOptionsBuilder<ContextWithNameOrdering>()
+            .UseSqlServer("Server=.;Database=Test;Trusted_Connection=True")
+            .UseDefaultOrderBy()
+            .Options;
+
+        using (var context = new ContextWithNameOrdering(options1))
+        {
+            _ = context.Model;
+        }
+
+        // Second context configures SharedEntity with OrderByDescending(Value) - should throw
+        var options2 = new DbContextOptionsBuilder<ContextWithValueOrdering>()
+            .UseSqlServer("Server=.;Database=Test;Trusted_Connection=True")
+            .UseDefaultOrderBy()
+            .Options;
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+        {
+            using var context = new ContextWithValueOrdering(options2);
+            _ = context.Model;
+        });
+
+        Assert.That(exception!.Message, Does.Contain("SharedEntity"));
+        Assert.That(exception.Message, Does.Contain("Conflicting"));
+    }
+}
+
+public class SharedEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+    public string Value { get; set; } = "";
+}
+
+class ContextWithNameOrdering(DbContextOptions options) : DbContext(options)
+{
+    public DbSet<SharedEntity> Entities => Set<SharedEntity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+        modelBuilder.Entity<SharedEntity>()
+            .OrderBy(_ => _.Name);
+}
+
+class ContextWithValueOrdering(DbContextOptions options) : DbContext(options)
+{
+    public DbSet<SharedEntity> Entities => Set<SharedEntity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+        modelBuilder.Entity<SharedEntity>()
+            .OrderByDescending(_ => _.Value);
 }

--- a/src/Tests/RequireOrderingTests.cs
+++ b/src/Tests/RequireOrderingTests.cs
@@ -113,9 +113,9 @@ class ContextAllOrdering(DbContextOptions<ContextAllOrdering> options)
     {
         base.OnModelCreating(modelBuilder);
 
-        // All entities have ordering configured
+        // All entities have ordering configured (must match TestDbContext's ordering)
         modelBuilder.Entity<TestEntity>()
-            .OrderBy(_ => _.CreatedDate);
+            .OrderByDescending(_ => _.CreatedDate);
     }
 }
 


### PR DESCRIPTION
Add runtime validation to Configuration.Cache to detect and reject conflicting default ordering configurations for the same entity type across different DbContext types, throwing an InvalidOperationException when ClauseMetadataList differs. Add tests to cover the new behavior (MigrationTests.ConflictingOrderingAcrossContexts_Throws), introduce SharedEntity and supporting contexts, and add ThenBy/ThenByDesc test entities and contexts. Also adjust RequireOrderingTests to match the expected ordering and bump package version to 0.3.2 in Directory.Build.props.