### PR TITLE
Fix ordering detection and placement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,7 @@ https://nuget.org/packages/EfOrderBy/
 
 - **Automatic ordering**: Queries without explicit `OrderBy` automatically use configured default ordering
 - **Include() support**: Nested collections in `.Include()` expressions are automatically ordered
+- **Deterministic paging**: Ordering is applied before `Skip`/`Take`/`First`, so pages and single results are stable
 - **Inheritance support**: Ordering configured on a base entity type is automatically inherited by derived types (TPH)
 - **Fluent configuration**: Configure default ordering using the familiar EF Core fluent API
 - **Multi-column ordering**: Chain multiple ordering clauses with `ThenBy` and `ThenByDescending`
@@ -82,6 +83,37 @@ var employeesByName = await context.Employees
 <!-- endSnippet -->
 
 
+## Paging and Single Results
+
+The default ordering is applied *before* any operator that chooses which rows come back, so
+`Skip`, `Take`, `First`, `FirstOrDefault`, `Last`, `LastOrDefault` and `ElementAt` all select
+from an ordered sequence:
+
+<!-- snippet: PagingAndSingleResults -->
+<a id='snippet-PagingAndSingleResults'></a>
+```cs
+// The ordering is applied before the page is taken, so the page is
+// taken from an ordered sequence rather than sorted after the fact
+var secondPage = await context.Employees
+    .Skip(20)
+    .Take(20)
+    .ToListAsync();
+
+// Ordered by HireDate, then Salary descending, so this is the
+// earliest hire rather than an arbitrary row
+var first = await context.Employees
+    .FirstAsync();
+```
+<sup><a href='/src/Tests/Snippets.cs#L89-L103' title='Snippet source file'>snippet source</a> | <a href='#snippet-PagingAndSingleResults' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Without this, a page would be an arbitrary set of rows that happens to be sorted, and pages
+could both skip and repeat rows.
+
+Aggregates such as `Count` and `Any`, and `Single`, are left alone, since ordering them is
+pointless work.
+
+
 ## Include() Support
 
 Nested collections in `.Include()` expressions are automatically ordered:
@@ -95,7 +127,7 @@ var departments = await context.Departments
     .Include(_ => _.Employees)
     .ToListAsync();
 ```
-<sup><a href='/src/Tests/Snippets.cs#L89-L97' title='Snippet source file'>snippet source</a> | <a href='#snippet-IncludeSupport' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Snippets.cs#L110-L118' title='Snippet source file'>snippet source</a> | <a href='#snippet-IncludeSupport' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -149,7 +181,7 @@ public class InheritanceDbContext : DbContext
     public DbSet<DerivedEntityB> DerivedEntitiesB => Set<DerivedEntityB>();
 }
 ```
-<sup><a href='/src/Tests/Snippets.cs#L165-L210' title='Snippet source file'>snippet source</a> | <a href='#snippet-InheritanceOrdering' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Snippets.cs#L186-L231' title='Snippet source file'>snippet source</a> | <a href='#snippet-InheritanceOrdering' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Behavior:
@@ -172,7 +204,7 @@ builder.Entity<Product>()
     .ThenBy(_ => _.Name)
     .ThenByDescending(_ => _.Price);
 ```
-<sup><a href='/src/Tests/Snippets.cs#L102-L109' title='Snippet source file'>snippet source</a> | <a href='#snippet-MultiColumnOrdering' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Snippets.cs#L123-L130' title='Snippet source file'>snippet source</a> | <a href='#snippet-MultiColumnOrdering' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -422,7 +454,7 @@ public class AppDbContext : DbContext
     public DbSet<Employee> Employees => Set<Employee>();
 }
 ```
-<sup><a href='/src/Tests/Snippets.cs#L113-L156' title='Snippet source file'>snippet source</a> | <a href='#snippet-CompleteExample' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Snippets.cs#L134-L177' title='Snippet source file'>snippet source</a> | <a href='#snippet-CompleteExample' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/src/EfOrderBy/Configuration.cs
+++ b/src/EfOrderBy/Configuration.cs
@@ -59,15 +59,22 @@ sealed class Configuration(Type elementType)
     /// Creates a new Configuration for a derived type by replaying the clause metadata.
     /// The derived type must have the same properties (inherited from the base).
     /// </summary>
+    // The default lookup omits non public properties, which an entity can map,
+    // so without these the ordering fails to inherit for those properties.
+    const BindingFlags propertyFlags =
+        BindingFlags.Public |
+        BindingFlags.NonPublic |
+        BindingFlags.Instance;
+
     internal Configuration CreateForDerivedType(Type derivedType)
     {
         var derived = new Configuration(derivedType) { IsInherited = true };
         foreach (var meta in ClauseMetadataList)
         {
-            var prop = derivedType.GetProperty(meta.PropertyName);
-            if (prop != null)
+            var property = derivedType.GetProperty(meta.PropertyName, propertyFlags);
+            if (property != null)
             {
-                derived.AddClause(prop, meta.Descending, meta.IsThenBy);
+                derived.AddClause(property, meta.Descending, meta.IsThenBy);
                 continue;
             }
 

--- a/src/EfOrderBy/IncludeOrderingApplicator.cs
+++ b/src/EfOrderBy/IncludeOrderingApplicator.cs
@@ -4,7 +4,7 @@
 sealed class IncludeOrderingApplicator(IModel model, bool detectRedundantOrdering) :
     ExpressionVisitor
 {
-    static readonly ConcurrentDictionary<Type, Type?> collectionElementTypeCache = new();
+    // MakeGenericMethod is expensive enough to be worth caching, unlike the element type lookup
     static readonly ConcurrentDictionary<(MethodInfo, Type), MethodInfo> includeMethodCache = new();
 
     protected override Expression VisitMethodCall(MethodCallExpression node)
@@ -112,35 +112,36 @@ sealed class IncludeOrderingApplicator(IModel model, bool detectRedundantOrderin
         return result;
     }
 
-    static Type? GetCollectionElementType(Type type) =>
-        collectionElementTypeCache.GetOrAdd(type,
-            static type =>
+    // Not cached. A navigation is declared as one of the types below, so the fast path is a
+    // handful of type comparisons, which is cheaper than a dictionary lookup and does not pin
+    // every type it is handed for the life of the process.
+    static Type? GetCollectionElementType(Type type)
+    {
+        // Check for IEnumerable<T>
+        if (type.IsGenericType)
+        {
+            var genericDef = type.GetGenericTypeDefinition();
+            if (genericDef == typeof(IEnumerable<>) ||
+                genericDef == typeof(ICollection<>) ||
+                genericDef == typeof(IList<>) ||
+                genericDef == typeof(List<>))
             {
-                // Check for IEnumerable<T>
-                if (type.IsGenericType)
-                {
-                    var genericDef = type.GetGenericTypeDefinition();
-                    if (genericDef == typeof(IEnumerable<>) ||
-                        genericDef == typeof(ICollection<>) ||
-                        genericDef == typeof(IList<>) ||
-                        genericDef == typeof(List<>))
-                    {
-                        return type.GetGenericArguments()[0];
-                    }
-                }
+                return type.GetGenericArguments()[0];
+            }
+        }
 
-                // Check interfaces
-                foreach (var iface in type.GetInterfaces())
-                {
-                    if (iface.IsGenericType &&
-                        iface.GetGenericTypeDefinition() == typeof(IEnumerable<>))
-                    {
-                        return iface.GetGenericArguments()[0];
-                    }
-                }
+        // Check interfaces
+        foreach (var iface in type.GetInterfaces())
+        {
+            if (iface.IsGenericType &&
+                iface.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            {
+                return iface.GetGenericArguments()[0];
+            }
+        }
 
-                return null;
-            });
+        return null;
+    }
 
     Configuration? GetConfiguration(Type element)
     {

--- a/src/EfOrderBy/IncludeOrderingApplicator.cs
+++ b/src/EfOrderBy/IncludeOrderingApplicator.cs
@@ -45,7 +45,7 @@ sealed class IncludeOrderingApplicator(IModel model, bool detectRedundantOrderin
         }
 
         // Check if the navigation already has ordering
-        if (Interceptor.HasOrdering(lambda.Body))
+        if (QueryAnalyzer.HasOrdering(lambda.Body))
         {
             // Already has explicit ordering, don't apply default
             if (detectRedundantOrdering)

--- a/src/EfOrderBy/Interceptor.cs
+++ b/src/EfOrderBy/Interceptor.cs
@@ -23,10 +23,9 @@ sealed class Interceptor : IQueryExpressionInterceptor
         var queryWithOrderedIncludes = visitor.Visit(query);
 
         // Analyze the query for ordering and includes in a single pass
-        var analyzer = new QueryAnalyzer();
-        analyzer.Visit(queryWithOrderedIncludes);
+        var (hasOrdering, hasInclude) = QueryAnalyzer.Analyze(queryWithOrderedIncludes);
 
-        if (analyzer.HasOrdering)
+        if (hasOrdering)
         {
             if (detectRedundantOrdering)
             {
@@ -60,14 +59,7 @@ sealed class Interceptor : IQueryExpressionInterceptor
 
         // Apply default ordering to the top-level query
         // If there's a Select projection at the end, we need to insert OrderBy before it
-        return ApplyOrderingBeforeSelect(queryWithOrderedIncludes, configuration, analyzer.HasInclude);
-    }
-
-    public static bool HasOrdering(Expression expression)
-    {
-        var analyzer = new QueryAnalyzer();
-        analyzer.Visit(expression);
-        return analyzer.HasOrdering;
+        return ApplyOrderingBeforeSelect(queryWithOrderedIncludes, configuration, hasInclude);
     }
 
     static Expression GetSourceBeforeProjection(Expression expression)

--- a/src/EfOrderBy/Interceptor.cs
+++ b/src/EfOrderBy/Interceptor.cs
@@ -14,16 +14,28 @@ sealed class Interceptor : IQueryExpressionInterceptor
         }
 
         var model = context.Model;
-        RequiredOrder.Validate(context);
 
-        var detectRedundantOrdering = RedundantOrder.IsEnabled(context);
+        // Both of the options below live on the same extension, so resolve it once
+        var extension = context.GetService<IDbContextOptions>()
+            .FindExtension<OrderRequiredExtension>();
 
-        // First, process Include nodes to add ordering to nested collections
-        var visitor = new IncludeOrderingApplicator(model, detectRedundantOrdering);
-        var queryWithOrderedIncludes = visitor.Visit(query);
+        RequiredOrder.Validate(context, extension);
+
+        var detectRedundantOrdering = extension?.ThrowOnRedundantOrderBy ?? false;
 
         // Analyze the query for ordering and includes in a single pass
-        var (hasOrdering, _) = QueryAnalyzer.Analyze(queryWithOrderedIncludes);
+        var (hasOrdering, hasInclude) = QueryAnalyzer.Analyze(query);
+
+        var queryWithOrderedIncludes = query;
+
+        // Ordering nested collections rewrites the whole tree, so only do it when there is an
+        // Include to rewrite. Neither flag above can change as a result, since the rewrite only
+        // touches the inside of Include lambdas.
+        if (hasInclude)
+        {
+            var visitor = new IncludeOrderingApplicator(model, detectRedundantOrdering);
+            queryWithOrderedIncludes = visitor.Visit(query);
+        }
 
         if (hasOrdering)
         {

--- a/src/EfOrderBy/Interceptor.cs
+++ b/src/EfOrderBy/Interceptor.cs
@@ -3,8 +3,6 @@
 /// </summary>
 sealed class Interceptor : IQueryExpressionInterceptor
 {
-    static readonly ConcurrentDictionary<Type, Type?> queryElementTypeCache = new();
-
     public Expression QueryCompilationStarting(Expression query, QueryExpressionEventData eventData)
     {
         var context = eventData.Context;
@@ -129,30 +127,32 @@ sealed class Interceptor : IQueryExpressionInterceptor
         return expression;
     }
 
-    static Type? GetQueryElementType(Type type) =>
-        queryElementTypeCache.GetOrAdd(type, static type =>
+    // Not cached. A query root is already IQueryable<T>, so the fast path below is two type
+    // comparisons, which is cheaper than a dictionary lookup and does not pin every type it
+    // is handed for the life of the process.
+    static Type? GetQueryElementType(Type type)
+    {
+        if (type.IsGenericType)
         {
-            if (type.IsGenericType)
+            var genericDef = type.GetGenericTypeDefinition();
+            if (genericDef == typeof(IQueryable<>) ||
+                genericDef == typeof(IOrderedQueryable<>))
             {
-                var genericDef = type.GetGenericTypeDefinition();
-                if (genericDef == typeof(IQueryable<>) ||
-                    genericDef == typeof(IOrderedQueryable<>))
-                {
-                    return type.GetGenericArguments()[0];
-                }
+                return type.GetGenericArguments()[0];
             }
+        }
 
-            foreach (var iface in type.GetInterfaces())
+        foreach (var iface in type.GetInterfaces())
+        {
+            if (iface.IsGenericType &&
+                iface.GetGenericTypeDefinition() == typeof(IQueryable<>))
             {
-                if (iface.IsGenericType &&
-                    iface.GetGenericTypeDefinition() == typeof(IQueryable<>))
-                {
-                    return iface.GetGenericArguments()[0];
-                }
+                return iface.GetGenericArguments()[0];
             }
+        }
 
-            return null;
-        });
+        return null;
+    }
 
     static Expression ApplyOrdering(Expression query, Configuration configuration)
     {

--- a/src/EfOrderBy/Interceptor.cs
+++ b/src/EfOrderBy/Interceptor.cs
@@ -23,7 +23,7 @@ sealed class Interceptor : IQueryExpressionInterceptor
         var queryWithOrderedIncludes = visitor.Visit(query);
 
         // Analyze the query for ordering and includes in a single pass
-        var (hasOrdering, hasInclude) = QueryAnalyzer.Analyze(queryWithOrderedIncludes);
+        var (hasOrdering, _) = QueryAnalyzer.Analyze(queryWithOrderedIncludes);
 
         if (hasOrdering)
         {
@@ -35,12 +35,11 @@ sealed class Interceptor : IQueryExpressionInterceptor
             return queryWithOrderedIncludes;
         }
 
-        // For queries with Select projection, we need to get the entity type from the source
-        // BEFORE the Select, not from the result type (which would be the projected type)
-        // Walk through Select/Include to find the actual source entity type
-        var sourceExpression = GetSourceBeforeProjection(queryWithOrderedIncludes);
+        // The entity type has to come from the source the ordering will be applied to, not from
+        // the result type, which may be a projection, a single entity, or a limited page
+        var source = GetOrderingSource(queryWithOrderedIncludes);
 
-        var elementType = GetQueryElementType(sourceExpression.Type);
+        var elementType = GetQueryElementType(source.Type);
         if (elementType == null)
         {
             return queryWithOrderedIncludes;
@@ -57,37 +56,62 @@ sealed class Interceptor : IQueryExpressionInterceptor
             return queryWithOrderedIncludes;
         }
 
-        // Apply default ordering to the top-level query
-        // If there's a Select projection at the end, we need to insert OrderBy before it
-        return ApplyOrderingBeforeSelect(queryWithOrderedIncludes, configuration, hasInclude);
+        return ApplyOrdering(queryWithOrderedIncludes, configuration);
     }
 
-    static Expression GetSourceBeforeProjection(Expression expression)
+    /// <summary>
+    /// Operators the default ordering has to be applied beneath rather than after.
+    /// </summary>
+    /// <remarks>
+    /// Skip, Take and the single result operators choose which rows come back, so ordering
+    /// them afterwards sorts an arbitrary subset instead of choosing from an ordered one.
+    /// Select projects the entity away. EF Core replaces ordering that sits outside an Include
+    /// with key ordering. The rest only tag the query and pass their source through unchanged.
+    /// </remarks>
+    static bool ShouldOrderBefore(MethodCallExpression call)
     {
-        // Walk through Select and Include to find the source entity expression
-        while (expression is MethodCallExpression call)
+        var declaringType = call.Method.DeclaringType;
+        var name = call.Method.Name;
+
+        if (declaringType == typeof(Queryable))
         {
-            var method = call.Method.Name;
-            var declaringType = call.Method.DeclaringType;
+            return name is
+                "Select" or
+                "Skip" or
+                "Take" or
+                "First" or
+                "FirstOrDefault" or
+                "Last" or
+                "LastOrDefault" or
+                "ElementAt" or
+                "ElementAtOrDefault";
+        }
 
-            // Skip over Select projections
-            if (declaringType == typeof(Queryable) &&
-                method == "Select")
-            {
-                expression = call.Arguments[0];
-                continue;
-            }
+        if (declaringType == typeof(EntityFrameworkQueryableExtensions))
+        {
+            return name is
+                "Include" or
+                "ThenInclude" or
+                "AsTracking" or
+                "AsNoTracking" or
+                "AsNoTrackingWithIdentityResolution" or
+                "AsSingleQuery" or
+                "AsSplitQuery" or
+                "IgnoreAutoIncludes" or
+                "IgnoreQueryFilters" or
+                "TagWith" or
+                "TagWithCallSite";
+        }
 
-            // Skip over Include operations
-            if (declaringType == typeof(EntityFrameworkQueryableExtensions) &&
-                method is "Include" or "ThenInclude")
-            {
-                expression = call.Arguments[0];
-                continue;
-            }
+        return false;
+    }
 
-            // Stop at any other operation
-            break;
+    static Expression GetOrderingSource(Expression expression)
+    {
+        while (expression is MethodCallExpression call &&
+               ShouldOrderBefore(call))
+        {
+            expression = call.Arguments[0];
         }
 
         return expression;
@@ -118,66 +142,21 @@ sealed class Interceptor : IQueryExpressionInterceptor
             return null;
         });
 
-    static Expression ApplyOrderingBeforeSelect(Expression query, Configuration configuration, bool hasInclude)
+    static Expression ApplyOrdering(Expression query, Configuration configuration)
     {
-        // Check if the query contains Include first - need to apply ordering before Include
-        // to prevent EF Core from replacing it with just Id ordering
-        // This must be checked before Select, because queries can be: OrderBy().Include().Select()
-        if (hasInclude)
-        {
-            return ApplyOrderingBeforeInclude(query, configuration);
-        }
-
-        // Check if the query ends with a Select call
+        // Push past everything the ordering has to precede, then rebuild the chain around it
         if (query is MethodCallExpression call &&
-            call.Method.DeclaringType == typeof(Queryable) &&
-            call.Method.Name == "Select")
+            ShouldOrderBefore(call))
         {
-            // Apply ordering to the source of the Select, then recreate the Select
-            var orderedSource = ApplyOrdering(call.Arguments[0], configuration);
-            return Expression.Call(call.Method, orderedSource, call.Arguments[1]);
+            var arguments = call.Arguments.ToArray();
+            arguments[0] = ApplyOrdering(arguments[0], configuration);
+            return call.Update(call.Object, arguments);
         }
 
-        // No Select or Include, apply ordering normally
-        return ApplyOrdering(query, configuration);
+        return AppendOrdering(query, configuration);
     }
 
-    static Expression ApplyOrderingBeforeInclude(Expression query, Configuration configuration)
-    {
-        // Check if the query ends with a Select call (after Include)
-        if (query is MethodCallExpression selectCall &&
-            selectCall.Method.DeclaringType == typeof(Queryable) &&
-            selectCall.Method.Name == "Select")
-        {
-            // Recursively apply ordering before Include in the source, then recreate Select
-            var orderedSource = ApplyOrderingBeforeInclude(selectCall.Arguments[0], configuration);
-            return Expression.Call(selectCall.Method, orderedSource, selectCall.Arguments[1]);
-        }
-
-        // Find the last method call before Include
-        if (query is MethodCallExpression methodCall &&
-            methodCall.Method.DeclaringType == typeof(EntityFrameworkQueryableExtensions) &&
-            methodCall.Method.Name is "Include" or "ThenInclude")
-        {
-            // Apply ordering to the source of the Include, then recreate the Include
-            var orderedSource = ApplyOrderingBeforeInclude(methodCall.Arguments[0], configuration);
-
-            // Recreate the Include call with the ordered source
-            var args = new Expression[methodCall.Arguments.Count];
-            args[0] = orderedSource;
-            for (var i = 1; i < methodCall.Arguments.Count; i++)
-            {
-                args[i] = methodCall.Arguments[i];
-            }
-
-            return Expression.Call(methodCall.Method, args);
-        }
-
-        // No Include at this level, apply ordering here
-        return ApplyOrdering(query, configuration);
-    }
-
-    static Expression ApplyOrdering(Expression source, Configuration configuration)
+    static Expression AppendOrdering(Expression source, Configuration configuration)
     {
         var result = source;
 

--- a/src/EfOrderBy/OrderByClause.cs
+++ b/src/EfOrderBy/OrderByClause.cs
@@ -26,38 +26,40 @@
         quotedLambda = Expression.Quote(lambda);
     }
 
-    static MethodInfo FindMethod(MethodInfo[] methods, string name) =>
-        methods.First(_ => _.Name == name &&
-                           _.GetParameters().Length == 2);
+    // The overload taking a comparer cannot be expressed as configuration, so match on the
+    // two parameter one. The method table is not held in a field, since keeping it alive for
+    // the life of the process buys nothing once these eight have been resolved.
+    static MethodInfo FindMethod(Type type, string name) =>
+        type.GetMethods()
+            .First(_ => _.Name == name &&
+                        _.GetParameters().Length == 2);
 
-    static MethodInfo[] queryableMethods = typeof(Queryable).GetMethods();
-    static MethodInfo[] enumerableMethods = typeof(Enumerable).GetMethods();
+    static readonly MethodInfo queryableOrderBy = FindMethod(typeof(Queryable), nameof(Queryable.OrderBy));
+    static readonly MethodInfo queryableOrderByDescending = FindMethod(typeof(Queryable), nameof(Queryable.OrderByDescending));
+    static readonly MethodInfo queryableThenBy = FindMethod(typeof(Queryable), nameof(Queryable.ThenBy));
+    static readonly MethodInfo queryableThenByDescending = FindMethod(typeof(Queryable), nameof(Queryable.ThenByDescending));
 
-    static MethodInfo queryableOrderBy = FindMethod(queryableMethods, nameof(Queryable.OrderBy));
-    static MethodInfo queryableOrderByDescending = FindMethod(queryableMethods, nameof(Queryable.OrderByDescending));
-    static MethodInfo queryableThenBy = FindMethod(queryableMethods, nameof(Queryable.ThenBy));
-    static MethodInfo queryableThenByDescending = FindMethod(queryableMethods, nameof(Queryable.ThenByDescending));
+    static readonly MethodInfo enumerableOrderBy = FindMethod(typeof(Enumerable), nameof(Enumerable.OrderBy));
+    static readonly MethodInfo enumerableOrderByDescending = FindMethod(typeof(Enumerable), nameof(Enumerable.OrderByDescending));
+    static readonly MethodInfo enumerableThenBy = FindMethod(typeof(Enumerable), nameof(Enumerable.ThenBy));
+    static readonly MethodInfo enumerableThenByDescending = FindMethod(typeof(Enumerable), nameof(Enumerable.ThenByDescending));
 
-    static MethodInfo enumerableOrderBy = FindMethod(enumerableMethods, nameof(Enumerable.OrderBy));
-    static MethodInfo enumerableOrderByDescending = FindMethod(enumerableMethods, nameof(Enumerable.OrderByDescending));
-    static MethodInfo enumerableThenBy = FindMethod(enumerableMethods, nameof(Enumerable.ThenBy));
-    static MethodInfo enumerableThenByDescending = FindMethod(enumerableMethods, nameof(Enumerable.ThenByDescending));
-    LambdaExpression lambda;
+    readonly LambdaExpression lambda;
 
     // The fully generic Enumerable method (e.g., OrderBy<ParentEntity, string>)
     // ready to be invoked without further generic type arguments.
-    MethodInfo enumerableMethod;
+    readonly MethodInfo enumerableMethod;
 
     // The fully generic Queryable method (e.g., OrderBy<ParentEntity, string>)
     // ready to be invoked without further generic type arguments.
-    MethodInfo queryableMethod;
+    readonly MethodInfo queryableMethod;
 
     public Expression AppendEnumerableOrder(Expression result) =>
         // Enumerable methods expect Func<T, TKey>, so we pass the lambda directly (no Quote)
         Expression.Call(enumerableMethod, result, lambda);
 
     // Queryable methods expect Expression<Func<T, TKey>>, so we use Quote()
-    UnaryExpression quotedLambda;
+    readonly UnaryExpression quotedLambda;
 
     public Expression AppendQueryableOrder(Expression result) =>
         Expression.Call(queryableMethod, result, quotedLambda);

--- a/src/EfOrderBy/OrderByExtensions.cs
+++ b/src/EfOrderBy/OrderByExtensions.cs
@@ -5,7 +5,7 @@ namespace EfOrderBy;
 /// </summary>
 public static class OrderByExtensions
 {
-    static Interceptor interceptor = new();
+    static readonly Interceptor interceptor = new();
 
     /// <summary>
     /// Adds the default ordering interceptor to automatically apply ordering to queries

--- a/src/EfOrderBy/QueryAnalyzer.cs
+++ b/src/EfOrderBy/QueryAnalyzer.cs
@@ -1,46 +1,53 @@
-﻿sealed class QueryAnalyzer :
-    ExpressionVisitor
+/// <summary>
+/// Scans the outermost chain of a query for existing ordering and for Include calls.
+/// </summary>
+/// <remarks>
+/// Only the chain is walked, never the lambdas passed to it. Ordering nested inside a lambda,
+/// for example Where(_ => _.Children.OrderBy(child => child.Name).Any()), orders a subquery and
+/// must not suppress the default ordering of the query it is nested in.
+/// </remarks>
+static class QueryAnalyzer
 {
-    public bool HasOrdering { get; private set; }
-    public bool HasInclude { get; private set; }
-
-    protected override Expression VisitMethodCall(MethodCallExpression node)
+    public static (bool HasOrdering, bool HasInclude) Analyze(Expression expression)
     {
-        var name = node.Method.Name;
-        var type = node.Method.DeclaringType;
+        var hasOrdering = false;
+        var hasInclude = false;
 
-        // Check if this is an Include/ThenInclude - don't look for ordering inside its lambda
-        if (type == typeof(EntityFrameworkQueryableExtensions) &&
-            name is "Include" or "ThenInclude")
+        while (expression is MethodCallExpression call)
         {
-            HasInclude = true;
-            // Visit the source (first argument) but skip the lambda (second argument)
-            // to avoid detecting ordering within Include(_ => _.Collection.OrderBy(...))
-            Visit(node.Arguments[0]);
-            return node;
+            var method = call.Method;
+            var declaringType = method.DeclaringType;
+            var name = method.Name;
+
+            if (declaringType == typeof(EntityFrameworkQueryableExtensions) &&
+                name is "Include" or "ThenInclude")
+            {
+                hasInclude = true;
+            }
+            else if ((declaringType == typeof(Queryable) ||
+                      declaringType == typeof(Enumerable)) &&
+                     name is
+                         "OrderBy" or
+                         "OrderByDescending" or
+                         "ThenBy" or
+                         "ThenByDescending")
+            {
+                hasOrdering = true;
+            }
+
+            // Only static operators compose a chain, and the source is always their first argument
+            if (!method.IsStatic ||
+                call.Arguments.Count == 0)
+            {
+                break;
+            }
+
+            expression = call.Arguments[0];
         }
 
-        // Check if this is a Select - don't look for ordering inside its lambda
-        if (type == typeof(Queryable) &&
-            name == "Select")
-        {
-            // Visit the source (first argument) but skip the lambda (second argument)
-            // to avoid detecting ordering within Select(_ => new { ... _.Children.OrderBy(...) })
-            Visit(node.Arguments[0]);
-            return node;
-        }
-
-        if ((type == typeof(Queryable) ||
-             type == typeof(Enumerable)) &&
-            name is
-                "OrderBy" or
-                "OrderByDescending" or
-                "ThenBy" or
-                "ThenByDescending")
-        {
-            HasOrdering = true;
-        }
-
-        return base.VisitMethodCall(node);
+        return (hasOrdering, hasInclude);
     }
+
+    public static bool HasOrdering(Expression expression) =>
+        Analyze(expression).HasOrdering;
 }

--- a/src/EfOrderBy/RedundantOrder.cs
+++ b/src/EfOrderBy/RedundantOrder.cs
@@ -3,12 +3,6 @@
 /// </summary>
 static class RedundantOrder
 {
-    public static bool IsEnabled(DbContext context) =>
-        context.GetService<IDbContextOptions>()
-            .FindExtension<OrderRequiredExtension>()
-            ?.ThrowOnRedundantOrderBy ??
-        false;
-
     public static void Validate(Expression expression)
     {
         if (FindOrdering(expression) is not { } ordering)

--- a/src/EfOrderBy/RedundantOrder.cs
+++ b/src/EfOrderBy/RedundantOrder.cs
@@ -90,12 +90,34 @@ static class RedundantOrder
         return (elementType, clauses);
     }
 
+    // Operators that combine two sequences. Their first argument is only one side of the
+    // query, and the default ordering is never applied to the combined result, so ordering
+    // found down that side is not made redundant by it.
+    static readonly HashSet<string> combining =
+    [
+        "Concat",
+        "Except",
+        "ExceptBy",
+        "GroupJoin",
+        "Intersect",
+        "IntersectBy",
+        "Join",
+        "LeftJoin",
+        "RightJoin",
+        "SequenceEqual",
+        "Union",
+        "UnionBy",
+        "Zip"
+    ];
+
     // Ordering can sit behind calls like Where, AsNoTracking, or TagWith,
     // all of which take the query being composed as their first argument.
     static Expression? FindSource(MethodCallExpression call)
     {
-        if (call.Method.IsStatic &&
+        var method = call.Method;
+        if (method.IsStatic &&
             call.Arguments.Count > 0 &&
+            !combining.Contains(method.Name) &&
             typeof(IEnumerable).IsAssignableFrom(call.Arguments[0].Type))
         {
             return call.Arguments[0];

--- a/src/EfOrderBy/RedundantOrder.cs
+++ b/src/EfOrderBy/RedundantOrder.cs
@@ -55,8 +55,7 @@ static class RedundantOrder
                     return null;
                 }
 
-                // The chain is walked outermost first, so each clause found is applied before the previous
-                clauses.Insert(0, new(propertyName, descending, isThenBy));
+                clauses.Add(new(propertyName, descending, isThenBy));
                 elementType = method.GetGenericArguments()[0];
                 expression = call.Arguments[0];
                 continue;
@@ -81,6 +80,8 @@ static class RedundantOrder
             return null;
         }
 
+        // The chain is walked outermost first, so the clauses come out in reverse of how they apply
+        clauses.Reverse();
         return (elementType, clauses);
     }
 

--- a/src/EfOrderBy/RequiredOrder.cs
+++ b/src/EfOrderBy/RequiredOrder.cs
@@ -1,6 +1,6 @@
 static class RequiredOrder
 {
-    static ConcurrentDictionary<Type, bool> validated = [];
+    static readonly ConcurrentDictionary<Type, bool> validated = [];
 
     public static void Validate(DbContext context, OrderRequiredExtension? extension)
     {

--- a/src/EfOrderBy/RequiredOrder.cs
+++ b/src/EfOrderBy/RequiredOrder.cs
@@ -2,7 +2,7 @@ static class RequiredOrder
 {
     static ConcurrentDictionary<Type, bool> validated = [];
 
-    public static void Validate(DbContext context)
+    public static void Validate(DbContext context, OrderRequiredExtension? extension)
     {
         var contextType = context.GetType();
 
@@ -12,12 +12,8 @@ static class RequiredOrder
             return;
         }
 
-        // Check if this DbContext requires ordering for all entities (opt-in feature)
-        var requireOrdering = context.GetService<IDbContextOptions>()
-            .FindExtension<OrderRequiredExtension>()
-            ?.RequireOrderingForAllEntities ?? false;
-
-        if (requireOrdering)
+        // Requiring ordering for all entities is opt-in
+        if (extension is { RequireOrderingForAllEntities: true })
         {
             ValidateAllEntitiesHaveOrdering(context.Model);
         }

--- a/src/Tests/InheritedOrderingTests.cs
+++ b/src/Tests/InheritedOrderingTests.cs
@@ -1,0 +1,49 @@
+[TestFixture]
+public class InheritedOrderingTests
+{
+    static DbContextOptions options =
+        new DbContextOptionsBuilder<InternalOrderContext>()
+            .UseSqlServer("Server=.;Database=Test;")
+            .UseDefaultOrderBy()
+            .Options;
+
+    [Test]
+    public void NonPublicProperty_InheritsOrderingToDerivedType()
+    {
+        using var context = new InternalOrderContext(options);
+
+        var sql = context.Derived.ToQueryString();
+
+        Assert.That(sql, Does.Contain("ORDER BY"));
+        Assert.That(sql, Does.Contain("SortOrder"));
+    }
+}
+
+public class InternalOrderBase
+{
+    public int Id { get; set; }
+
+    // Mapped explicitly below, since conventions only pick up public properties
+    internal int SortOrder { get; set; }
+}
+
+public class InternalOrderDerived : InternalOrderBase
+{
+    public string Extra { get; set; } = "";
+}
+
+public class InternalOrderContext(DbContextOptions options) :
+    DbContext(options)
+{
+    public DbSet<InternalOrderBase> Bases => Set<InternalOrderBase>();
+    public DbSet<InternalOrderDerived> Derived => Set<InternalOrderDerived>();
+
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        builder.Entity<InternalOrderBase>()
+            .Property(_ => _.SortOrder);
+
+        builder.Entity<InternalOrderBase>()
+            .OrderBy(_ => _.SortOrder);
+    }
+}

--- a/src/Tests/NestedOrderingTests.OrderingInsideAnyLambda_StillAppliesDefaultOrder.verified.txt
+++ b/src/Tests/NestedOrderingTests.OrderingInsideAnyLambda_StillAppliesDefaultOrder.verified.txt
@@ -1,0 +1,61 @@
+﻿{
+  target: [
+    {
+      Id: 6,
+      DepartmentId: 3,
+      Name: Frank,
+      HireDate: 2024-04-10,
+      Salary: 65000
+    },
+    {
+      Id: 2,
+      DepartmentId: 1,
+      Name: Bob,
+      HireDate: 2024-03-20,
+      Salary: 85000
+    },
+    {
+      Id: 4,
+      DepartmentId: 2,
+      Name: Diana,
+      HireDate: 2024-02-05,
+      Salary: 70000
+    },
+    {
+      Id: 1,
+      DepartmentId: 1,
+      Name: Alice,
+      HireDate: 2024-01-15,
+      Salary: 90000
+    },
+    {
+      Id: 5,
+      DepartmentId: 2,
+      Name: Eve,
+      HireDate: 2023-11-01,
+      Salary: 72000
+    },
+    {
+      Id: 3,
+      DepartmentId: 1,
+      Name: Charlie,
+      HireDate: 2023-06-10,
+      Salary: 95000
+    }
+  ],
+  sql: {
+    Text:
+select   e.Id,
+         e.DepartmentId,
+         e.HireDate,
+         e.Name,
+         e.Salary
+from     Employees as e
+where    not exists (select 1
+                     from   EmployeeTasks as e0
+                     where  e.Id = e0.EmployeeId
+                            and e0.Priority < 0)
+order by e.HireDate desc,
+    HasTransaction: false
+  }
+}

--- a/src/Tests/NestedOrderingTests.OrderingInsideIncludeFilter_StillOrdersNestedCollection.verified.txt
+++ b/src/Tests/NestedOrderingTests.OrderingInsideIncludeFilter_StillOrdersNestedCollection.verified.txt
@@ -1,0 +1,94 @@
+﻿{
+  target: [
+    {
+      Id: 1,
+      Name: Engineering,
+      DisplayOrder: 1,
+      Employees: [
+        {
+          Id: 2,
+          DepartmentId: 1,
+          Name: Bob,
+          HireDate: 2024-03-20,
+          Salary: 85000
+        },
+        {
+          Id: 1,
+          DepartmentId: 1,
+          Name: Alice,
+          HireDate: 2024-01-15,
+          Salary: 90000
+        },
+        {
+          Id: 3,
+          DepartmentId: 1,
+          Name: Charlie,
+          HireDate: 2023-06-10,
+          Salary: 95000
+        }
+      ]
+    },
+    {
+      Id: 2,
+      Name: Sales,
+      DisplayOrder: 2,
+      Employees: [
+        {
+          Id: 4,
+          DepartmentId: 2,
+          Name: Diana,
+          HireDate: 2024-02-05,
+          Salary: 70000
+        },
+        {
+          Id: 5,
+          DepartmentId: 2,
+          Name: Eve,
+          HireDate: 2023-11-01,
+          Salary: 72000
+        }
+      ]
+    },
+    {
+      Id: 3,
+      Name: HR,
+      DisplayOrder: 3,
+      Employees: [
+        {
+          Id: 6,
+          DepartmentId: 3,
+          Name: Frank,
+          HireDate: 2024-04-10,
+          Salary: 65000
+        }
+      ]
+    }
+  ],
+  sql: {
+    Text:
+select   d.Id,
+         d.DisplayOrder,
+         d.Name,
+         e1.Id,
+         e1.DepartmentId,
+         e1.HireDate,
+         e1.Name,
+         e1.Salary
+from     Departments as d
+         left outer join
+         (select e.Id,
+                 e.DepartmentId,
+                 e.HireDate,
+                 e.Name,
+                 e.Salary
+          from   Employees as e
+          where  (select COUNT(*)
+                  from   EmployeeTasks as e0
+                  where  e.Id = e0.EmployeeId) >= 0) as e1
+         on d.Id = e1.DepartmentId
+order by d.DisplayOrder,
+         d.Id,
+         e1.HireDate desc,
+    HasTransaction: false
+  }
+}

--- a/src/Tests/NestedOrderingTests.OrderingInsideSelectManyLambda_StillAppliesDefaultOrder.verified.txt
+++ b/src/Tests/NestedOrderingTests.OrderingInsideSelectManyLambda_StillAppliesDefaultOrder.verified.txt
@@ -1,0 +1,60 @@
+﻿{
+  target: [
+    {
+      Id: 6,
+      DepartmentId: 3,
+      Name: Frank,
+      HireDate: 2024-04-10,
+      Salary: 65000
+    },
+    {
+      Id: 2,
+      DepartmentId: 1,
+      Name: Bob,
+      HireDate: 2024-03-20,
+      Salary: 85000
+    },
+    {
+      Id: 4,
+      DepartmentId: 2,
+      Name: Diana,
+      HireDate: 2024-02-05,
+      Salary: 70000
+    },
+    {
+      Id: 1,
+      DepartmentId: 1,
+      Name: Alice,
+      HireDate: 2024-01-15,
+      Salary: 90000
+    },
+    {
+      Id: 5,
+      DepartmentId: 2,
+      Name: Eve,
+      HireDate: 2023-11-01,
+      Salary: 72000
+    },
+    {
+      Id: 3,
+      DepartmentId: 1,
+      Name: Charlie,
+      HireDate: 2023-06-10,
+      Salary: 95000
+    }
+  ],
+  sql: {
+    Text:
+select   e.Id,
+         e.DepartmentId,
+         e.HireDate,
+         e.Name,
+         e.Salary
+from     Departments as d
+         inner join
+         Employees as e
+         on d.Id = e.DepartmentId
+order by e.HireDate desc,
+    HasTransaction: false
+  }
+}

--- a/src/Tests/NestedOrderingTests.OrderingInsideWhereLambda_StillAppliesDefaultOrder.verified.txt
+++ b/src/Tests/NestedOrderingTests.OrderingInsideWhereLambda_StillAppliesDefaultOrder.verified.txt
@@ -1,0 +1,60 @@
+﻿{
+  target: [
+    {
+      Id: 6,
+      DepartmentId: 3,
+      Name: Frank,
+      HireDate: 2024-04-10,
+      Salary: 65000
+    },
+    {
+      Id: 2,
+      DepartmentId: 1,
+      Name: Bob,
+      HireDate: 2024-03-20,
+      Salary: 85000
+    },
+    {
+      Id: 4,
+      DepartmentId: 2,
+      Name: Diana,
+      HireDate: 2024-02-05,
+      Salary: 70000
+    },
+    {
+      Id: 1,
+      DepartmentId: 1,
+      Name: Alice,
+      HireDate: 2024-01-15,
+      Salary: 90000
+    },
+    {
+      Id: 5,
+      DepartmentId: 2,
+      Name: Eve,
+      HireDate: 2023-11-01,
+      Salary: 72000
+    },
+    {
+      Id: 3,
+      DepartmentId: 1,
+      Name: Charlie,
+      HireDate: 2023-06-10,
+      Salary: 95000
+    }
+  ],
+  sql: {
+    Text:
+select   e.Id,
+         e.DepartmentId,
+         e.HireDate,
+         e.Name,
+         e.Salary
+from     Employees as e
+where    (select COUNT(*)
+          from   EmployeeTasks as e0
+          where  e.Id = e0.EmployeeId) >= 0
+order by e.HireDate desc,
+    HasTransaction: false
+  }
+}

--- a/src/Tests/NestedOrderingTests.cs
+++ b/src/Tests/NestedOrderingTests.cs
@@ -1,0 +1,84 @@
+// Ordering that appears inside a lambda belongs to a subquery. It must not be mistaken
+// for explicit ordering of the query the lambda is nested in.
+[TestFixture]
+public class NestedOrderingTests
+{
+    [Test]
+    public async Task OrderingInsideWhereLambda_StillAppliesDefaultOrder()
+    {
+        await using var database = await ModuleInitializer.SqlInstance.Build();
+        await using var context = database.NewDbContext();
+
+        Recording.Start();
+        var results = await context.Employees
+            .Where(_ => _.Tasks.OrderBy(task => task.Title).Count() >= 0)
+            .ToListAsync();
+
+        // Employees keep their default ordering of HireDate descending
+        Assert.That(results.Select(_ => _.Name), Is.EqualTo(new[]
+        {
+            "Frank",   // 2024-04-10
+            "Bob",     // 2024-03-20
+            "Diana",   // 2024-02-05
+            "Alice",   // 2024-01-15
+            "Eve",     // 2023-11-01
+            "Charlie"  // 2023-06-10
+        }));
+        await Verify(results);
+    }
+
+    [Test]
+    public async Task OrderingInsideAnyLambda_StillAppliesDefaultOrder()
+    {
+        await using var database = await ModuleInitializer.SqlInstance.Build();
+        await using var context = database.NewDbContext();
+
+        Recording.Start();
+        var results = await context.Employees
+            .Where(_ => !_.Tasks.OrderBy(task => task.Title).Any(task => task.Priority < 0))
+            .ToListAsync();
+
+        Assert.That(results[0].Name, Is.EqualTo("Frank"));
+        Assert.That(results[^1].Name, Is.EqualTo("Charlie"));
+        await Verify(results);
+    }
+
+    [Test]
+    public async Task OrderingInsideSelectManyLambda_StillAppliesDefaultOrder()
+    {
+        await using var database = await ModuleInitializer.SqlInstance.Build();
+        await using var context = database.NewDbContext();
+
+        Recording.Start();
+        var results = await context.Departments
+            .SelectMany(_ => _.Employees.OrderBy(employee => employee.Name))
+            .ToListAsync();
+
+        // The projected employees get their own default ordering of HireDate descending
+        Assert.That(results[0].Name, Is.EqualTo("Frank"));
+        Assert.That(results[^1].Name, Is.EqualTo("Charlie"));
+        await Verify(results);
+    }
+
+    [Test]
+    public async Task OrderingInsideIncludeFilter_StillOrdersNestedCollection()
+    {
+        await using var database = await ModuleInitializer.SqlInstance.Build();
+        await using var context = database.NewDbContext();
+
+        Recording.Start();
+        var results = await context.Departments
+            .Include(_ => _.Employees.Where(employee => employee.Tasks.OrderBy(task => task.Title).Count() >= 0))
+            .ToListAsync();
+
+        // The ordering inside the filter applies to Tasks, so Employees still get their default
+        var engineering = results[0].Employees;
+        Assert.That(engineering.Select(_ => _.Name), Is.EqualTo(new[]
+        {
+            "Bob",     // 2024-03-20
+            "Alice",   // 2024-01-15
+            "Charlie"  // 2023-06-10
+        }));
+        await Verify(results);
+    }
+}

--- a/src/Tests/RedundantOrderByTests.cs
+++ b/src/Tests/RedundantOrderByTests.cs
@@ -208,6 +208,39 @@ public class RedundantOrderByTests
     }
 
     [Test]
+    public void ExactMatchInsideConcat_DoesNotThrow()
+    {
+        using var context = new RedundantEnabledContext(enabled);
+
+        // The default ordering is not applied to a combined sequence, so ordering one
+        // side of it is not redundant
+        Assert.DoesNotThrow(
+            () => context.Entities
+                .Where(_ => _.Priority > 1)
+                .OrderBy(_ => _.Name)
+                .ThenByDescending(_ => _.Priority)
+                .Concat(context.Entities.Where(_ => _.Priority <= 1))
+                .ToQueryString());
+    }
+
+    [Test]
+    public void ExactMatchInsideJoin_DoesNotThrow()
+    {
+        using var context = new RedundantEnabledContext(enabled);
+
+        Assert.DoesNotThrow(
+            () => context.Entities
+                .OrderBy(_ => _.Name)
+                .ThenByDescending(_ => _.Priority)
+                .Join(
+                    context.Children,
+                    entity => entity.Id,
+                    child => child.RedundantEntityId,
+                    (entity, child) => child.Title)
+                .ToQueryString());
+    }
+
+    [Test]
     public void Disabled_DoesNotThrow()
     {
         using var context = new RedundantDisabledContext(disabled);

--- a/src/Tests/RowLimitingTests.Count_DoesNotApplyOrdering.verified.txt
+++ b/src/Tests/RowLimitingTests.Count_DoesNotApplyOrdering.verified.txt
@@ -1,0 +1,9 @@
+﻿{
+  target: 6,
+  sql: {
+    Text:
+select COUNT(*)
+from   Employees as e,
+    HasTransaction: false
+  }
+}

--- a/src/Tests/RowLimitingTests.ElementAt_AppliesDefaultOrder.verified.txt
+++ b/src/Tests/RowLimitingTests.ElementAt_AppliesDefaultOrder.verified.txt
@@ -1,0 +1,24 @@
+﻿{
+  target: {
+    Id: 4,
+    DepartmentId: 2,
+    Name: Diana,
+    HireDate: 2024-02-05,
+    Salary: 70000
+  },
+  sql: {
+    Text:
+select   e.Id,
+         e.DepartmentId,
+         e.HireDate,
+         e.Name,
+         e.Salary
+from     Employees as e
+order by e.HireDate desc
+offset @p rows fetch next 1 rows only,
+    Parameters: {
+      @p: 2
+    },
+    HasTransaction: false
+  }
+}

--- a/src/Tests/RowLimitingTests.FirstOrDefaultWithPredicate_AppliesDefaultOrder.verified.txt
+++ b/src/Tests/RowLimitingTests.FirstOrDefaultWithPredicate_AppliesDefaultOrder.verified.txt
@@ -1,0 +1,21 @@
+﻿{
+  target: {
+    Id: 2,
+    DepartmentId: 1,
+    Name: Bob,
+    HireDate: 2024-03-20,
+    Salary: 85000
+  },
+  sql: {
+    Text:
+select   top (1) e.Id,
+                 e.DepartmentId,
+                 e.HireDate,
+                 e.Name,
+                 e.Salary
+from     Employees as e
+where    e.Salary > 70000
+order by e.HireDate desc,
+    HasTransaction: false
+  }
+}

--- a/src/Tests/RowLimitingTests.First_AppliesDefaultOrder.verified.txt
+++ b/src/Tests/RowLimitingTests.First_AppliesDefaultOrder.verified.txt
@@ -1,0 +1,20 @@
+﻿{
+  target: {
+    Id: 6,
+    DepartmentId: 3,
+    Name: Frank,
+    HireDate: 2024-04-10,
+    Salary: 65000
+  },
+  sql: {
+    Text:
+select   top (1) e.Id,
+                 e.DepartmentId,
+                 e.HireDate,
+                 e.Name,
+                 e.Salary
+from     Employees as e
+order by e.HireDate desc,
+    HasTransaction: false
+  }
+}

--- a/src/Tests/RowLimitingTests.IncludeThenPage_OrdersBeforeLimiting.verified.txt
+++ b/src/Tests/RowLimitingTests.IncludeThenPage_OrdersBeforeLimiting.verified.txt
@@ -1,0 +1,52 @@
+﻿{
+  target: [
+    {
+      Id: 2,
+      Name: Sales,
+      DisplayOrder: 2,
+      Employees: [
+        {
+          Id: 4,
+          DepartmentId: 2,
+          Name: Diana,
+          HireDate: 2024-02-05,
+          Salary: 70000
+        },
+        {
+          Id: 5,
+          DepartmentId: 2,
+          Name: Eve,
+          HireDate: 2023-11-01,
+          Salary: 72000
+        }
+      ]
+    }
+  ],
+  sql: {
+    Text:
+select   d0.Id,
+         d0.DisplayOrder,
+         d0.Name,
+         e.Id,
+         e.DepartmentId,
+         e.HireDate,
+         e.Name,
+         e.Salary
+from     (select   d.Id,
+                   d.DisplayOrder,
+                   d.Name
+          from     Departments as d
+          order by d.DisplayOrder
+          offset @p rows fetch next @p rows only) as d0
+         left outer join
+         Employees as e
+         on d0.Id = e.DepartmentId
+order by d0.DisplayOrder,
+         d0.Id,
+         e.HireDate desc,
+    Parameters: {
+      @p: 1
+    },
+    HasTransaction: false
+  }
+}

--- a/src/Tests/RowLimitingTests.SelectThenFirst_AppliesDefaultOrderToSource.verified.txt
+++ b/src/Tests/RowLimitingTests.SelectThenFirst_AppliesDefaultOrderToSource.verified.txt
@@ -1,0 +1,10 @@
+﻿{
+  target: Frank,
+  sql: {
+    Text:
+select   top (1) e.Name
+from     Employees as e
+order by e.HireDate desc,
+    HasTransaction: false
+  }
+}

--- a/src/Tests/RowLimitingTests.Single_DoesNotApplyOrdering.verified.txt
+++ b/src/Tests/RowLimitingTests.Single_DoesNotApplyOrdering.verified.txt
@@ -1,0 +1,20 @@
+﻿{
+  target: {
+    Id: 5,
+    DepartmentId: 2,
+    Name: Eve,
+    HireDate: 2023-11-01,
+    Salary: 72000
+  },
+  sql: {
+    Text:
+select top (2) e.Id,
+               e.DepartmentId,
+               e.HireDate,
+               e.Name,
+               e.Salary
+from   Employees as e
+where  e.Name = N'Eve',
+    HasTransaction: false
+  }
+}

--- a/src/Tests/RowLimitingTests.SkipTake_OrdersBeforeLimiting.verified.txt
+++ b/src/Tests/RowLimitingTests.SkipTake_OrdersBeforeLimiting.verified.txt
@@ -1,0 +1,34 @@
+﻿{
+  target: [
+    {
+      Id: 2,
+      DepartmentId: 1,
+      Name: Bob,
+      HireDate: 2024-03-20,
+      Salary: 85000
+    },
+    {
+      Id: 4,
+      DepartmentId: 2,
+      Name: Diana,
+      HireDate: 2024-02-05,
+      Salary: 70000
+    }
+  ],
+  sql: {
+    Text:
+select   e.Id,
+         e.DepartmentId,
+         e.HireDate,
+         e.Name,
+         e.Salary
+from     Employees as e
+order by e.HireDate desc
+offset @p rows fetch next @p1 rows only,
+    Parameters: {
+      @p: 1,
+      @p1: 2
+    },
+    HasTransaction: false
+  }
+}

--- a/src/Tests/RowLimitingTests.Take_OrdersBeforeLimiting.verified.txt
+++ b/src/Tests/RowLimitingTests.Take_OrdersBeforeLimiting.verified.txt
@@ -1,0 +1,39 @@
+﻿{
+  target: [
+    {
+      Id: 6,
+      DepartmentId: 3,
+      Name: Frank,
+      HireDate: 2024-04-10,
+      Salary: 65000
+    },
+    {
+      Id: 2,
+      DepartmentId: 1,
+      Name: Bob,
+      HireDate: 2024-03-20,
+      Salary: 85000
+    },
+    {
+      Id: 4,
+      DepartmentId: 2,
+      Name: Diana,
+      HireDate: 2024-02-05,
+      Salary: 70000
+    }
+  ],
+  sql: {
+    Text:
+select   top (@p) e.Id,
+                  e.DepartmentId,
+                  e.HireDate,
+                  e.Name,
+                  e.Salary
+from     Employees as e
+order by e.HireDate desc,
+    Parameters: {
+      @p: 3
+    },
+    HasTransaction: false
+  }
+}

--- a/src/Tests/RowLimitingTests.cs
+++ b/src/Tests/RowLimitingTests.cs
@@ -1,0 +1,143 @@
+// The default ordering has to be applied before any operator that chooses rows, otherwise
+// an arbitrary subset is chosen first and only then sorted.
+[TestFixture]
+public class RowLimitingTests
+{
+    // Employees in default order of HireDate descending:
+    // Frank, Bob, Diana, Alice, Eve, Charlie
+
+    [Test]
+    public async Task Take_OrdersBeforeLimiting()
+    {
+        await using var database = await ModuleInitializer.SqlInstance.Build();
+        await using var context = database.NewDbContext();
+
+        Recording.Start();
+        var results = await context.Employees
+            .Take(3)
+            .ToListAsync();
+
+        Assert.That(results.Select(_ => _.Name), Is.EqualTo(new[] { "Frank", "Bob", "Diana" }));
+        await Verify(results);
+    }
+
+    [Test]
+    public async Task SkipTake_OrdersBeforeLimiting()
+    {
+        await using var database = await ModuleInitializer.SqlInstance.Build();
+        await using var context = database.NewDbContext();
+
+        Recording.Start();
+        var results = await context.Employees
+            .Skip(1)
+            .Take(2)
+            .ToListAsync();
+
+        Assert.That(results.Select(_ => _.Name), Is.EqualTo(new[] { "Bob", "Diana" }));
+        await Verify(results);
+    }
+
+    [Test]
+    public async Task IncludeThenPage_OrdersBeforeLimiting()
+    {
+        await using var database = await ModuleInitializer.SqlInstance.Build();
+        await using var context = database.NewDbContext();
+
+        Recording.Start();
+        var results = await context.Departments
+            .Include(_ => _.Employees)
+            .Skip(1)
+            .Take(1)
+            .ToListAsync();
+
+        // Departments in default order are Engineering, Sales, HR
+        Assert.That(results.Single().Name, Is.EqualTo("Sales"));
+
+        // The included collection keeps its own default ordering
+        Assert.That(results[0].Employees.Select(_ => _.Name), Is.EqualTo(new[] { "Diana", "Eve" }));
+        await Verify(results);
+    }
+
+    [Test]
+    public async Task First_AppliesDefaultOrder()
+    {
+        await using var database = await ModuleInitializer.SqlInstance.Build();
+        await using var context = database.NewDbContext();
+
+        Recording.Start();
+        var result = await context.Employees.FirstAsync();
+
+        Assert.That(result.Name, Is.EqualTo("Frank"));
+        await Verify(result);
+    }
+
+    [Test]
+    public async Task FirstOrDefaultWithPredicate_AppliesDefaultOrder()
+    {
+        await using var database = await ModuleInitializer.SqlInstance.Build();
+        await using var context = database.NewDbContext();
+
+        Recording.Start();
+        var result = await context.Employees.FirstOrDefaultAsync(_ => _.Salary > 70000);
+
+        // Of Alice, Bob, Charlie and Eve, Bob was hired most recently
+        Assert.That(result!.Name, Is.EqualTo("Bob"));
+        await Verify(result);
+    }
+
+    [Test]
+    public async Task SelectThenFirst_AppliesDefaultOrderToSource()
+    {
+        await using var database = await ModuleInitializer.SqlInstance.Build();
+        await using var context = database.NewDbContext();
+
+        Recording.Start();
+        var result = await context.Employees
+            .Select(_ => _.Name)
+            .FirstAsync();
+
+        Assert.That(result, Is.EqualTo("Frank"));
+        await Verify(result);
+    }
+
+    [Test]
+    public async Task ElementAt_AppliesDefaultOrder()
+    {
+        await using var database = await ModuleInitializer.SqlInstance.Build();
+        await using var context = database.NewDbContext();
+
+        Recording.Start();
+        var result = await context.Employees.ElementAtAsync(2);
+
+        Assert.That(result.Name, Is.EqualTo("Diana"));
+        await Verify(result);
+    }
+
+    [Test]
+    public async Task Count_DoesNotApplyOrdering()
+    {
+        await using var database = await ModuleInitializer.SqlInstance.Build();
+        await using var context = database.NewDbContext();
+
+        Recording.Start();
+        var result = await context.Employees.CountAsync();
+
+        // Ordering an aggregate is pointless work, so it must be left alone
+        Assert.That(result, Is.EqualTo(6));
+        await Verify(result);
+    }
+
+    [Test]
+    public async Task Single_DoesNotApplyOrdering()
+    {
+        await using var database = await ModuleInitializer.SqlInstance.Build();
+        await using var context = database.NewDbContext();
+
+        Recording.Start();
+        var result = await context.Employees.SingleAsync(_ => _.Name == "Eve");
+
+        // Single matches at most one row, so ordering it is pointless work
+        Assert.That(result.Salary, Is.EqualTo(72000));
+        await Verify(result);
+    }
+}

--- a/src/Tests/Snippets.cs
+++ b/src/Tests/Snippets.cs
@@ -82,6 +82,27 @@ public class SnippetExamples
         #endregion
     }
 
+    static async Task PagingAndSingleResults()
+    {
+        AppDbContext context = null!;
+
+        #region PagingAndSingleResults
+
+        // The ordering is applied before the page is taken, so the page is
+        // taken from an ordered sequence rather than sorted after the fact
+        var secondPage = await context.Employees
+            .Skip(20)
+            .Take(20)
+            .ToListAsync();
+
+        // Ordered by HireDate, then Salary descending, so this is the
+        // earliest hire rather than an arbitrary row
+        var first = await context.Employees
+            .FirstAsync();
+
+        #endregion
+    }
+
     static async Task IncludeSupport()
     {
         AppDbContext context = null!;


### PR DESCRIPTION
Four correctness fixes and two performance changes, one commit each.

## Ordering nested in a lambda suppressed the default ordering

`QueryAnalyzer` was an `ExpressionVisitor` that descended into every node, including the lambdas passed to operators. Any `OrderBy` inside a subquery lambda set `HasOrdering`, so the query was treated as explicitly ordered and got no default ordering at all:

```cs
context.Employees.Where(_ => _.Tasks.OrderBy(task => task.Title).Count() >= 0)
```

```sql
-- before: no ORDER BY at all
select e.Id, ... from Employees as e where (select COUNT(*) ...) >= 0
```

`Include` and `Select` lambdas already had hand rolled guards against this. Every other operator did not, so `Where`, `Any`, `SelectMany` and `GroupBy` all triggered it, as did an ordering nested inside a filtered `Include`.

Replaced the visitor with a walk of the chain itself, which is the only place top level ordering and `Include` can appear.

## Ordering was applied after the operators that choose rows

Ordering was only pushed beneath `Select` and `Include`, and appended to the end of the chain otherwise. So `Take` produced:

```sql
select * from (select top(3) * from Employees) order by HireDate desc
```

Three arbitrary rows, sorted after the fact. Paging could skip and repeat rows across pages while looking correctly sorted, and EF Core still raised `RowLimitingOperationWithoutOrderByWarning`.

`First`, `FirstOrDefault`, `Last`, `LastOrDefault` and `ElementAt` were missed entirely: their result type is the entity rather than `IQueryable<T>`, so element type detection returned null and nothing was applied, leaving EF Core to raise `FirstWithoutOrderByAndFilterWarning`.

The two placement walks are now one predicate naming the operators the ordering has to precede, used both to find the source entity type and to insert the ordering. Aggregates and `Single` are excluded, since ordering them is pointless work, and snapshots assert they stay unordered.

## Redundant order detection walked into combined sequences

`FindSource` followed the first argument of any static method whose source looked enumerable, which includes `Concat`, `Union`, `Join` and friends. Ordering applied to one side was reported as redundant even though the default ordering is never applied to the combined result, so the advice to remove it was wrong.

## Inherited ordering could not see non public properties

`CreateForDerivedType` looked the property up with the default binding flags, which only match public members. Ordering configured on a mapped non public property failed to inherit with `Property 'SortOrder' not found on derived type 'Derived'`, even though the derived type does have it.

## Performance

Both are compile time only, since `QueryCompilationStarting` sits behind EF Core's compiled query cache.

- `IncludeOrderingApplicator` rebuilt the entire query tree on every compilation even when there was no `Include` to touch. The chain analysis already reports whether one is present, so it now runs first and gates the visit. The options extension is also resolved once instead of once each by `RequiredOrder` and `RedundantOrder`.
- Dropped the two element type caches. Both guard a fast path of a few type comparisons that is cheaper than the dictionary probe, and they pinned every type they were handed for the life of the process, which stops a collectible load context unloading. The `Include` method cache stays, since `MakeGenericMethod` is genuinely expensive. `OrderByClause` also no longer holds the `Queryable` and `Enumerable` method tables in static fields after resolving its eight methods.

## Notes

The second fix changes behaviour: `Take` now returns different rows than before, deterministic ones, and queries that previously tripped EF Core's row limiting and first without ordering warnings no longer do. That may warrant a major version bump rather than a patch.

Two things left alone deliberately. `Configuration.cache` still pins entity types for the process lifetime, since it is the config lookup on every compilation and has to be a real cache. `RequiredOrder.validated` still keys by `DbContext` type, so the same context type used with different `UseDefaultOrderBy` options would share a validation result; the tests already declare a separate context type per option combination, so the design was left as is.

## Verification

122 tests pass. Each fix has tests, and for the last two I confirmed they are regression tests by reverting the source fix and watching them fail.
