### PR TITLE
Add JSON column support for default ordering

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ https://nuget.org/packages/EfOrderBy/
 - **Inheritance support**: Ordering configured on a base entity type is automatically inherited by derived types (TPH)
 - **Fluent configuration**: Configure default ordering using the familiar EF Core fluent API
 - **Multi-column ordering**: Chain multiple ordering clauses with `ThenBy` and `ThenByDescending`
+- **JSON column support**: Order by a property inside a `ToJson()` mapped column, at any nesting depth
 - **Automatic indexes**: Database indexes are automatically created for ordering columns
 - **Validation mode**: Optionally require all entities to have default ordering configured
 - **Redundant ordering detection**: Optionally throw when a query explicitly applies the same ordering as the configured default, per context or process wide
@@ -79,7 +80,7 @@ var employeesByName = await context.Employees
     .OrderBy(_ => _.Name)
     .ToListAsync();
 ```
-<sup><a href='/src/Tests/Snippets.cs#L83-L94' title='Snippet source file'>snippet source</a> | <a href='#snippet-QueryWithoutOrderBy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Snippets.cs#L101-L112' title='Snippet source file'>snippet source</a> | <a href='#snippet-QueryWithoutOrderBy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -104,7 +105,7 @@ var secondPage = await context.Employees
 var first = await context.Employees
     .FirstAsync();
 ```
-<sup><a href='/src/Tests/Snippets.cs#L101-L115' title='Snippet source file'>snippet source</a> | <a href='#snippet-PagingAndSingleResults' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Snippets.cs#L119-L133' title='Snippet source file'>snippet source</a> | <a href='#snippet-PagingAndSingleResults' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Without this, a page would be an arbitrary set of rows that happens to be sorted, and pages
@@ -127,7 +128,7 @@ var departments = await context.Departments
     .Include(_ => _.Employees)
     .ToListAsync();
 ```
-<sup><a href='/src/Tests/Snippets.cs#L122-L130' title='Snippet source file'>snippet source</a> | <a href='#snippet-IncludeSupport' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Snippets.cs#L140-L148' title='Snippet source file'>snippet source</a> | <a href='#snippet-IncludeSupport' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -181,7 +182,7 @@ public class InheritanceDbContext : DbContext
     public DbSet<DerivedEntityB> DerivedEntitiesB => Set<DerivedEntityB>();
 }
 ```
-<sup><a href='/src/Tests/Snippets.cs#L198-L243' title='Snippet source file'>snippet source</a> | <a href='#snippet-InheritanceOrdering' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Snippets.cs#L228-L273' title='Snippet source file'>snippet source</a> | <a href='#snippet-InheritanceOrdering' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Behavior:
@@ -204,8 +205,71 @@ builder.Entity<Product>()
     .ThenBy(_ => _.Name)
     .ThenByDescending(_ => _.Price);
 ```
-<sup><a href='/src/Tests/Snippets.cs#L135-L142' title='Snippet source file'>snippet source</a> | <a href='#snippet-MultiColumnOrdering' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Snippets.cs#L153-L160' title='Snippet source file'>snippet source</a> | <a href='#snippet-MultiColumnOrdering' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+
+## JSON Columns
+
+Default ordering can target a property inside a column mapped with `ToJson()`. Pass the full property path, and EF Core translates it to a read of the JSON document:
+
+<!-- snippet: JsonColumnOrdering -->
+<a id='snippet-JsonColumnOrdering'></a>
+```cs
+protected override void OnModelCreating(ModelBuilder builder)
+{
+    builder.Entity<Order>()
+        .OwnsOne(_ => _.Metadata, _ => _.ToJson());
+
+    // Orders by a property of the JSON document rather than a column
+    builder.Entity<Order>()
+        .OrderByDescending(_ => _.Metadata.Priority)
+        .ThenBy(_ => _.Reference);
+}
+```
+<sup><a href='/src/Tests/Snippets.cs#L34-L47' title='Snippet source file'>snippet source</a> | <a href='#snippet-JsonColumnOrdering' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The above produces:
+
+```sql
+ORDER BY CAST(JSON_VALUE([o].[Metadata], '$.Priority') AS int) DESC, [o].[Reference]
+```
+
+Paths of any depth are supported, so an owned type nested inside another owned type works the same way:
+
+```cs
+builder.Entity<Article>()
+    .OrderByDescending(_ => _.Info.Audit.Modified);
+
+// ORDER BY CAST(JSON_VALUE([a].[Info], '$.Audit.Modified') AS datetime2) DESC
+```
+
+JSON properties can be mixed freely with ordinary columns in the same ordering chain.
+
+Everything else behaves as it does for a column: the ordering is applied before `Skip`/`Take`/`First`, explicit ordering in a query still takes precedence, and [redundant ordering detection](#detect-redundant-ordering) recognises the path.
+
+### Indexes for JSON properties
+
+A JSON property is not a column of the entity's table, so there is nothing to name in an index. Automatic index creation is skipped for any ordering that reaches into JSON — the ordering itself still applies. As with [string columns](#string-column-indexes), a composite ordering is skipped whole when any one of its clauses reaches into JSON.
+
+To index a JSON property, map a computed column over it and index that using the provider's own tooling.
+
+### JSON collections
+
+A collection mapped with `ToJson()` is read out of its parent's JSON document rather than joined, and EF Core rejects an ordered `Include` over one on a tracking query. Applying default ordering to such a collection would break queries that work today, so JSON collections are left in document order:
+
+```cs
+builder.Entity<Product>()
+    .OwnsMany(_ => _.Tags, _ => _.ToJson());
+
+// Tags come back in the order they are stored in the JSON array
+var products = await context.Products
+    .Include(_ => _.Tags)
+    .ToListAsync();
+```
+
+To control the order of a JSON collection, store it ordered, or sort it after materialization.
 
 
 ## Automatic Index Creation
@@ -287,7 +351,7 @@ protected override void OnConfiguring(DbContextOptionsBuilder builder) =>
     builder.UseDefaultOrderBy(
         createIndexes: false);
 ```
-<sup><a href='/src/Tests/Snippets.cs#L68-L74' title='Snippet source file'>snippet source</a> | <a href='#snippet-DisableIndexCreation' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Snippets.cs#L86-L92' title='Snippet source file'>snippet source</a> | <a href='#snippet-DisableIndexCreation' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 When index creation is disabled, calling `WithIndexName()` throws an `Exception`.
@@ -304,7 +368,7 @@ protected override void OnConfiguring(DbContextOptionsBuilder builder) =>
     builder.UseDefaultOrderBy(
         requireOrderingForAllEntities: true);
 ```
-<sup><a href='/src/Tests/Snippets.cs#L34-L40' title='Snippet source file'>snippet source</a> | <a href='#snippet-RequireOrdering' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Snippets.cs#L52-L58' title='Snippet source file'>snippet source</a> | <a href='#snippet-RequireOrdering' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 This throws an exception during the first query if any entity type lacks default ordering configuration:
@@ -331,7 +395,7 @@ protected override void OnConfiguring(DbContextOptionsBuilder builder) =>
     builder.UseDefaultOrderBy(
         throwOnRedundantOrderBy: true);
 ```
-<sup><a href='/src/Tests/Snippets.cs#L45-L51' title='Snippet source file'>snippet source</a> | <a href='#snippet-ThrowOnRedundantOrderBy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Snippets.cs#L63-L69' title='Snippet source file'>snippet source</a> | <a href='#snippet-ThrowOnRedundantOrderBy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Given this configuration:
@@ -412,7 +476,7 @@ protected override void OnConfiguring(DbContextOptionsBuilder builder) =>
     builder.UseDefaultOrderBy(
         throwOnRedundantOrderBy: false);
 ```
-<sup><a href='/src/Tests/Snippets.cs#L56-L63' title='Snippet source file'>snippet source</a> | <a href='#snippet-OptOutOfThrowOnRedundantOrderBy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Snippets.cs#L74-L81' title='Snippet source file'>snippet source</a> | <a href='#snippet-OptOutOfThrowOnRedundantOrderBy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The setting is read during query compilation rather than when the options are built, so it applies to contexts whose options were built before the initializer ran.
@@ -484,7 +548,7 @@ public class AppDbContext : DbContext
     public DbSet<Employee> Employees => Set<Employee>();
 }
 ```
-<sup><a href='/src/Tests/Snippets.cs#L146-L189' title='Snippet source file'>snippet source</a> | <a href='#snippet-CompleteExample' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Snippets.cs#L164-L207' title='Snippet source file'>snippet source</a> | <a href='#snippet-CompleteExample' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/src/EfOrderBy/Configuration.cs
+++ b/src/EfOrderBy/Configuration.cs
@@ -32,8 +32,16 @@ sealed class Configuration(Type elementType)
 
     /// <summary>
     /// Property names in order, used for creating composite indexes.
+    /// Only meaningful when <see cref="HasNestedPath" /> is false.
     /// </summary>
     internal List<string> PropertyNames { get; } = [];
+
+    /// <summary>
+    /// Whether any clause orders by a property reached through an owned type, for example a
+    /// property of a JSON mapped column. Those are not columns of the entity's own table, so
+    /// they cannot be named in an index.
+    /// </summary>
+    internal bool HasNestedPath { get; private set; }
 
     internal string? CustomIndexName { get; set; }
 
@@ -48,11 +56,17 @@ sealed class Configuration(Type elementType)
     /// </summary>
     internal List<ClauseMetadata> ClauseMetadataList { get; } = [];
 
-    internal void AddClause(PropertyInfo propertyInfo, bool descending, bool isThenBy)
+    internal void AddClause(PropertyInfo[] path, bool descending, bool isThenBy)
     {
-        Clauses.Add(new(elementType, parameter, propertyInfo, descending, isThenBy));
-        PropertyNames.Add(propertyInfo.Name);
-        ClauseMetadataList.Add(new(propertyInfo.Name, descending, isThenBy));
+        Clauses.Add(new(elementType, parameter, path, descending, isThenBy));
+
+        if (path.Length > 1)
+        {
+            HasNestedPath = true;
+        }
+
+        PropertyNames.Add(path[0].Name);
+        ClauseMetadataList.Add(new(PropertyPath.Describe(path), descending, isThenBy));
     }
 
     /// <summary>
@@ -71,18 +85,38 @@ sealed class Configuration(Type elementType)
         var derived = new Configuration(derivedType) { IsInherited = true };
         foreach (var meta in ClauseMetadataList)
         {
-            var property = derivedType.GetProperty(meta.PropertyName, propertyFlags);
-            if (property != null)
-            {
-                derived.AddClause(property, meta.Descending, meta.IsThenBy);
-                continue;
-            }
-
-            throw new($"Property '{meta.PropertyName}' not found on derived type '{derivedType.Name}'. Cannot inherit ordering from base type '{elementType.Name}'.");
+            derived.AddClause(ResolvePath(derivedType, meta.PropertyPath), meta.Descending, meta.IsThenBy);
         }
 
         return derived;
     }
 
-    internal readonly record struct ClauseMetadata(string PropertyName, bool Descending, bool IsThenBy);
+    // Only the first segment is declared by the entity, so only it changes on a derived type.
+    // The rest hang off the owned types the path reaches through and resolve the same way.
+    PropertyInfo[] ResolvePath(Type derivedType, string path)
+    {
+        var names = path.Split('.');
+        var resolved = new PropertyInfo[names.Length];
+        var declaring = derivedType;
+
+        for (var index = 0; index < names.Length; index++)
+        {
+            var property = declaring.GetProperty(names[index], propertyFlags);
+            if (property == null)
+            {
+                throw new($"Property '{path}' not found on derived type '{derivedType.Name}'. Cannot inherit ordering from base type '{elementType.Name}'.");
+            }
+
+            resolved[index] = property;
+            declaring = property.PropertyType;
+        }
+
+        return resolved;
+    }
+
+    /// <summary>
+    /// A clause as configured, with <paramref name="PropertyPath" /> dotted when the ordering
+    /// reaches through an owned type, for example "Metadata.Rank" for a JSON mapped column.
+    /// </summary>
+    internal readonly record struct ClauseMetadata(string PropertyPath, bool Descending, bool IsThenBy);
 }

--- a/src/EfOrderBy/Conventions/FinalizingConvention.cs
+++ b/src/EfOrderBy/Conventions/FinalizingConvention.cs
@@ -44,8 +44,12 @@ class FinalizingConvention(int? maxIndexableStringLength) : IModelFinalizingConv
                 continue;
             }
 
+            // A nested path orders by a property of an owned type, for example a property of a
+            // JSON column. That is not a column of this entity's table, so there is nothing to
+            // name in an index. The ordering itself still applies, the same as the skip below.
             if (createIndexes &&
                 !config.IsInherited &&
+                !config.HasNestedPath &&
                 !HasLargeStringProperty(entity, config, maxIndexableStringLength))
             {
                 var index = config.CustomIndexName ?? $"IX_{entity.ClrType.Name}_DefaultOrder";

--- a/src/EfOrderBy/IncludeOrderingApplicator.cs
+++ b/src/EfOrderBy/IncludeOrderingApplicator.cs
@@ -151,6 +151,14 @@ sealed class IncludeOrderingApplicator(IModel model, bool detectRedundantOrderin
             return null;
         }
 
+        // A JSON mapped collection is read out of its parent's JSON document rather than joined,
+        // and EF Core rejects an ordered Include over one on a tracking query. Ordering it would
+        // break queries that work today, so the document order is left as it is.
+        if (entity.IsMappedToJson())
+        {
+            return null;
+        }
+
         return Configuration.TryGet(element);
     }
 }

--- a/src/EfOrderBy/OrderByBuilder.cs
+++ b/src/EfOrderBy/OrderByBuilder.cs
@@ -11,11 +11,11 @@ public sealed class OrderByBuilder<TEntity>
     Configuration configuration;
     IMutableModel model;
 
-    internal OrderByBuilder(EntityTypeBuilder<TEntity> builder, PropertyInfo propertyInfo, bool descending)
+    internal OrderByBuilder(EntityTypeBuilder<TEntity> builder, PropertyInfo[] path, bool descending)
     {
         model = builder.Metadata.Model;
         configuration = new(typeof(TEntity));
-        configuration.AddClause(propertyInfo, descending, isThenBy: false);
+        configuration.AddClause(path, descending, isThenBy: false);
 
         builder.Metadata.SetOrderByConfiguration(configuration);
     }
@@ -25,8 +25,7 @@ public sealed class OrderByBuilder<TEntity>
     /// </summary>
     public OrderByBuilder<TEntity> ThenBy<TProperty>(Expression<Func<TEntity, TProperty>> property)
     {
-        var propertyInfo = GetPropertyInfo(property);
-        configuration.AddClause(propertyInfo, descending: false, isThenBy: true);
+        configuration.AddClause(PropertyPath.Resolve(property), descending: false, isThenBy: true);
         return this;
     }
 
@@ -35,8 +34,7 @@ public sealed class OrderByBuilder<TEntity>
     /// </summary>
     public OrderByBuilder<TEntity> ThenByDescending<TProperty>(Expression<Func<TEntity, TProperty>> property)
     {
-        var propertyInfo = GetPropertyInfo(property);
-        configuration.AddClause(propertyInfo, descending: true, isThenBy: true);
+        configuration.AddClause(PropertyPath.Resolve(property), descending: true, isThenBy: true);
         return this;
     }
 
@@ -63,18 +61,5 @@ public sealed class OrderByBuilder<TEntity>
 
         configuration.CustomIndexName = indexName;
         return this;
-    }
-
-    static PropertyInfo GetPropertyInfo<TProperty>(Expression<Func<TEntity, TProperty>> property)
-    {
-        if (property.Body is MemberExpression
-            {
-                Member: PropertyInfo propertyInfo
-            })
-        {
-            return propertyInfo;
-        }
-
-        throw new ArgumentException("Expression must be a property access expression", nameof(property));
     }
 }

--- a/src/EfOrderBy/OrderByClause.cs
+++ b/src/EfOrderBy/OrderByClause.cs
@@ -1,9 +1,15 @@
 ﻿sealed record OrderByClause
 {
-    internal OrderByClause(Type elementType, ParameterExpression parameter, PropertyInfo propertyInfo, bool descending, bool isThenBy)
+    internal OrderByClause(Type elementType, ParameterExpression parameter, PropertyInfo[] path, bool descending, bool isThenBy)
     {
-        // Pre-build the property access and lambda expression
-        var property = Expression.Property(parameter, propertyInfo);
+        // Pre-build the property access and lambda expression. The path has more than one entry
+        // when the ordering reaches through an owned type, for example into a JSON column.
+        Expression property = parameter;
+        foreach (var segment in path)
+        {
+            property = Expression.Property(property, segment);
+        }
+
         lambda = Expression.Lambda(property, parameter);
 
         MethodInfo genericQueryableMethod;
@@ -21,8 +27,9 @@
         }
 
         // Pre-compute the fully generic methods (e.g., OrderBy<ParentEntity, string>)
-        queryableMethod = genericQueryableMethod.MakeGenericMethod(elementType, propertyInfo.PropertyType);
-        enumerableMethod = genericEnumerableMethod.MakeGenericMethod(elementType, propertyInfo.PropertyType);
+        var keyType = path[^1].PropertyType;
+        queryableMethod = genericQueryableMethod.MakeGenericMethod(elementType, keyType);
+        enumerableMethod = genericEnumerableMethod.MakeGenericMethod(elementType, keyType);
         quotedLambda = Expression.Quote(lambda);
     }
 

--- a/src/EfOrderBy/OrderByExtensions.cs
+++ b/src/EfOrderBy/OrderByExtensions.cs
@@ -63,8 +63,7 @@ public static class OrderByExtensions
     {
         ThrowIfInterceptorNotRegistered(builder);
         ThrowIfOrderingAlreadyConfigured(builder);
-        var propertyInfo = GetPropertyInfo(property);
-        return new(builder, propertyInfo, descending: false);
+        return new(builder, PropertyPath.Resolve(property), descending: false);
     }
 
     /// <summary>
@@ -86,8 +85,7 @@ public static class OrderByExtensions
     {
         ThrowIfInterceptorNotRegistered(builder);
         ThrowIfOrderingAlreadyConfigured(builder);
-        var propertyInfo = GetPropertyInfo(property);
-        return new(builder, propertyInfo, descending: true);
+        return new(builder, PropertyPath.Resolve(property), descending: true);
     }
 
     // Entity-level annotation helpers
@@ -128,16 +126,6 @@ public static class OrderByExtensions
 
     internal static void MarkIndexCreationDisabled(this IConventionModelBuilder builder) =>
         builder.HasAnnotation(indexCreationDisabledAnnotation, true);
-
-    static PropertyInfo GetPropertyInfo<TEntity, TProperty>(Expression<Func<TEntity, TProperty>> property)
-    {
-        if (property.Body is MemberExpression { Member: PropertyInfo propertyInfo })
-        {
-            return propertyInfo;
-        }
-
-        throw new ArgumentException("Expression must be a property access expression", nameof(property));
-    }
 
     static void ThrowIfInterceptorNotRegistered<TEntity>(EntityTypeBuilder<TEntity> builder)
         where TEntity : class

--- a/src/EfOrderBy/PropertyPath.cs
+++ b/src/EfOrderBy/PropertyPath.cs
@@ -1,0 +1,50 @@
+/// <summary>
+/// Resolves the chain of properties a key selector reads.
+/// </summary>
+/// <remarks>
+/// A chain of more than one property reaches through an owned type, which is how a property of a
+/// JSON mapped column is addressed, for example <c>_ => _.Metadata.Rank</c>. EF Core translates
+/// those to a read of the JSON document, so the whole chain is kept rather than only its last
+/// property.
+/// </remarks>
+static class PropertyPath
+{
+    public static PropertyInfo[] Resolve<TEntity, TProperty>(Expression<Func<TEntity, TProperty>> property)
+    {
+        if (TryResolve(property.Body) is { } path)
+        {
+            return path;
+        }
+
+        throw new ArgumentException("Expression must be a property access expression", nameof(property));
+    }
+
+    /// <summary>
+    /// Returns the properties of a member chain rooted at the lambda parameter, outermost last,
+    /// or null when the expression is not such a chain.
+    /// </summary>
+    public static PropertyInfo[]? TryResolve(Expression? expression)
+    {
+        var segments = new List<PropertyInfo>();
+
+        while (expression is MemberExpression {Member: PropertyInfo property} member)
+        {
+            segments.Add(property);
+            expression = member.Expression;
+        }
+
+        // A chain that does not bottom out at the parameter, for example one rooted at a captured
+        // variable, a constant, or a method call, cannot be expressed as ordering configuration
+        if (segments.Count == 0 ||
+            expression is not ParameterExpression)
+        {
+            return null;
+        }
+
+        segments.Reverse();
+        return [..segments];
+    }
+
+    public static string Describe(IEnumerable<PropertyInfo> path) =>
+        string.Join('.', path.Select(_ => _.Name));
+}

--- a/src/EfOrderBy/RedundantOrder.cs
+++ b/src/EfOrderBy/RedundantOrder.cs
@@ -50,12 +50,12 @@ static class RedundantOrder
                     return null;
                 }
 
-                if (FindPropertyName(call.Arguments[1]) is not { } propertyName)
+                if (FindPropertyPath(call.Arguments[1]) is not { } propertyPath)
                 {
                     return null;
                 }
 
-                clauses.Add(new(propertyName, descending, isThenBy));
+                clauses.Add(new(propertyPath, descending, isThenBy));
                 elementType = method.GetGenericArguments()[0];
                 expression = call.Arguments[0];
                 continue;
@@ -154,7 +154,7 @@ static class RedundantOrder
     }
 
     // Queryable methods take a quoted lambda, Enumerable methods take the lambda directly
-    static string? FindPropertyName(Expression keySelector)
+    static string? FindPropertyPath(Expression keySelector)
     {
         if (keySelector is UnaryExpression
             {
@@ -165,23 +165,21 @@ static class RedundantOrder
             keySelector = quoted;
         }
 
-        if (keySelector is LambdaExpression
-            {
-                Body: MemberExpression
-                {
-                    Expression: ParameterExpression,
-                    Member: PropertyInfo property
-                }
-            })
+        if (keySelector is not LambdaExpression lambda)
         {
-            return property.Name;
+            return null;
         }
 
-        return null;
+        if (PropertyPath.TryResolve(lambda.Body) is not { } path)
+        {
+            return null;
+        }
+
+        return PropertyPath.Describe(path);
     }
 
     static string Describe(List<Configuration.ClauseMetadata> clauses) =>
-        string.Join('.', clauses.Select(_ => $"{MethodName(_)}({_.PropertyName})"));
+        string.Join('.', clauses.Select(_ => $"{MethodName(_)}({_.PropertyPath})"));
 
     static string MethodName(Configuration.ClauseMetadata clause) =>
         (clause.IsThenBy, clause.Descending) switch

--- a/src/Tests/JsonColumnTests.JsonProperty_AppliesDefaultOrder.verified.txt
+++ b/src/Tests/JsonColumnTests.JsonProperty_AppliesDefaultOrder.verified.txt
@@ -1,0 +1,49 @@
+﻿{
+  target: [
+    {
+      Id: 2,
+      Name: Gadget,
+      Metadata: {
+        Rank: 1,
+        Label: 
+      }
+    },
+    {
+      Id: 3,
+      Name: Doohickey,
+      Metadata: {
+        Rank: 2,
+        Label: 
+      }
+    },
+    {
+      Id: 1,
+      Name: Widget,
+      Metadata: {
+        Rank: 3,
+        Label: 
+      },
+      Tags: [
+        {
+          Value: gamma
+        },
+        {
+          Value: alpha
+        },
+        {
+          Value: beta
+        }
+      ]
+    }
+  ],
+  sql: {
+    Text:
+select   p.Id,
+         p.Name,
+         p.Metadata,
+         p.Tags
+from     Products as p
+order by cast (JSON_VALUE(p.Metadata, '$.Rank') as int),
+    HasTransaction: false
+  }
+}

--- a/src/Tests/JsonColumnTests.MixedColumnAndJsonProperties_AppliesDefaultOrder.verified.txt
+++ b/src/Tests/JsonColumnTests.MixedColumnAndJsonProperties_AppliesDefaultOrder.verified.txt
@@ -1,0 +1,39 @@
+﻿{
+  target: [
+    {
+      Id: 2,
+      Name: A-heavy,
+      Category: A,
+      Details: {
+        Weight: 9
+      }
+    },
+    {
+      Id: 3,
+      Name: A-light,
+      Category: A,
+      Details: {
+        Weight: 2
+      }
+    },
+    {
+      Id: 1,
+      Name: B-light,
+      Category: B,
+      Details: {
+        Weight: 1
+      }
+    }
+  ],
+  sql: {
+    Text:
+select   i.Id,
+         i.Category,
+         i.Name,
+         i.Details
+from     Items as i
+order by i.Category,
+         cast (JSON_VALUE(i.Details, '$.Weight') as int) desc,
+    HasTransaction: false
+  }
+}

--- a/src/Tests/JsonColumnTests.NestedJsonProperty_AppliesDefaultOrder.verified.txt
+++ b/src/Tests/JsonColumnTests.NestedJsonProperty_AppliesDefaultOrder.verified.txt
@@ -1,0 +1,40 @@
+﻿{
+  target: [
+    {
+      Id: 2,
+      Title: Newest,
+      Info: {
+        Audit: {
+          Modified: 2025-01-01
+        }
+      }
+    },
+    {
+      Id: 3,
+      Title: Middle,
+      Info: {
+        Audit: {
+          Modified: 2024-01-01
+        }
+      }
+    },
+    {
+      Id: 1,
+      Title: Oldest,
+      Info: {
+        Audit: {
+          Modified: 2023-01-01
+        }
+      }
+    }
+  ],
+  sql: {
+    Text:
+select   a.Id,
+         a.Title,
+         a.Info
+from     Articles as a
+order by cast (JSON_VALUE(a.Info, '$.Audit.Modified') as datetime2) desc,
+    HasTransaction: false
+  }
+}

--- a/src/Tests/JsonColumnTests.cs
+++ b/src/Tests/JsonColumnTests.cs
@@ -1,0 +1,410 @@
+// Ordering that reaches into a JSON mapped column. EF Core translates the property path to a
+// read of the JSON document, so the default ordering applies the same way it does to a column.
+[TestFixture]
+public class JsonColumnTests
+{
+    static readonly SqlInstance<JsonDbContext> sqlInstance = new(
+        constructInstance: builder =>
+        {
+            builder.UseDefaultOrderBy();
+            return new(builder.Options);
+        },
+        buildTemplate: async context =>
+        {
+            await context.Database.EnsureCreatedAsync();
+
+            context.Products.AddRange(
+                new()
+                {
+                    Name = "Widget",
+                    Metadata = new()
+                    {
+                        Rank = 3
+                    },
+                    Tags =
+                    [
+                        new() { Value = "gamma" },
+                        new() { Value = "alpha" },
+                        new() { Value = "beta" }
+                    ]
+                },
+                new()
+                {
+                    Name = "Gadget",
+                    Metadata = new()
+                    {
+                        Rank = 1
+                    }
+                },
+                new()
+                {
+                    Name = "Doohickey",
+                    Metadata = new()
+                    {
+                        Rank = 2
+                    }
+                });
+
+            context.Articles.AddRange(
+                new()
+                {
+                    Title = "Oldest",
+                    Info = new()
+                    {
+                        Audit = new()
+                        {
+                            Modified = new(2023, 1, 1)
+                        }
+                    }
+                },
+                new()
+                {
+                    Title = "Newest",
+                    Info = new()
+                    {
+                        Audit = new()
+                        {
+                            Modified = new(2025, 1, 1)
+                        }
+                    }
+                },
+                new()
+                {
+                    Title = "Middle",
+                    Info = new()
+                    {
+                        Audit = new()
+                        {
+                            Modified = new(2024, 1, 1)
+                        }
+                    }
+                });
+
+            context.Items.AddRange(
+                new()
+                {
+                    Name = "B-light",
+                    Category = "B",
+                    Details = new()
+                    {
+                        Weight = 1
+                    }
+                },
+                new()
+                {
+                    Name = "A-heavy",
+                    Category = "A",
+                    Details = new()
+                    {
+                        Weight = 9
+                    }
+                },
+                new()
+                {
+                    Name = "A-light",
+                    Category = "A",
+                    Details = new()
+                    {
+                        Weight = 2
+                    }
+                });
+
+            await context.SaveChangesAsync();
+        });
+
+    [Test]
+    public async Task JsonProperty_AppliesDefaultOrder()
+    {
+        await using var database = await sqlInstance.Build();
+        await using var context = database.NewDbContext();
+
+        Recording.Start();
+        var results = await context.Products.ToListAsync();
+
+        Assert.That(results.Select(_ => _.Name), Is.EqualTo(["Gadget", "Doohickey", "Widget"]));
+        await Verify(results);
+    }
+
+    [Test]
+    public async Task NestedJsonProperty_AppliesDefaultOrder()
+    {
+        await using var database = await sqlInstance.Build();
+        await using var context = database.NewDbContext();
+
+        Recording.Start();
+        var results = await context.Articles.ToListAsync();
+
+        // Info.Audit.Modified descending, two owned types deep
+        Assert.That(results.Select(_ => _.Title), Is.EqualTo(["Newest", "Middle", "Oldest"]));
+        await Verify(results);
+    }
+
+    [Test]
+    public async Task MixedColumnAndJsonProperties_AppliesDefaultOrder()
+    {
+        await using var database = await sqlInstance.Build();
+        await using var context = database.NewDbContext();
+
+        Recording.Start();
+        var results = await context.Items.ToListAsync();
+
+        // Category ascending, then Details.Weight descending
+        Assert.That(results.Select(_ => _.Name), Is.EqualTo(["A-heavy", "A-light", "B-light"]));
+        await Verify(results);
+    }
+
+    [Test]
+    public async Task ExplicitOrdering_SuppressesJsonDefault()
+    {
+        await using var database = await sqlInstance.Build();
+        await using var context = database.NewDbContext();
+
+        var results = await context.Products
+            .OrderBy(_ => _.Name)
+            .ToListAsync();
+
+        Assert.That(results.Select(_ => _.Name), Is.EqualTo(["Doohickey", "Gadget", "Widget"]));
+    }
+
+    [Test]
+    public async Task JsonProperty_AppliesBeneathTake()
+    {
+        await using var database = await sqlInstance.Build();
+        await using var context = database.NewDbContext();
+
+        // The default ordering has to be applied before Take, otherwise an arbitrary row is taken
+        var results = await context.Products
+            .Take(1)
+            .ToListAsync();
+
+        Assert.That(results.Single().Name, Is.EqualTo("Gadget"));
+    }
+
+    // A JSON mapped collection is read out of its parent's JSON document. EF Core throws on an
+    // ordered Include over one in a tracking query, so it has to be left in document order.
+    [Test]
+    public async Task JsonCollection_KeepsDocumentOrder()
+    {
+        await using var database = await sqlInstance.Build();
+        await using var context = database.NewDbContext();
+
+        var results = await context.Products
+            .Include(_ => _.Tags)
+            .ToListAsync();
+
+        var widget = results.Single(_ => _.Name == "Widget");
+        Assert.That(widget.Tags.Select(_ => _.Value), Is.EqualTo(["gamma", "alpha", "beta"]));
+    }
+
+    [Test]
+    public void JsonPath_SkipsIndexCreation()
+    {
+        using var context = NewModelOnlyContext();
+
+        // A JSON property is not a column of the entity's table, so there is nothing to index
+        var product = context.Model.FindEntityType(typeof(JsonProduct))!;
+        Assert.That(product.GetIndexes(), Is.Empty);
+
+        var article = context.Model.FindEntityType(typeof(JsonArticle))!;
+        Assert.That(article.GetIndexes(), Is.Empty);
+
+        // A composite ordering is skipped whole when any one of its clauses reaches into JSON
+        var item = context.Model.FindEntityType(typeof(JsonItem))!;
+        Assert.That(item.GetIndexes(), Is.Empty);
+    }
+
+    // Validation runs on the first query rather than when the model is built
+    [Test]
+    public void JsonOwnedTypes_DoNotRequireOrdering()
+    {
+        var builder = new DbContextOptionsBuilder<JsonRequiredContext>()
+            .UseSqlServer("Server=.;Database=Test;");
+        builder.UseDefaultOrderBy(requireOrderingForAllEntities: true);
+
+        using var context = new JsonRequiredContext(builder.Options);
+
+        // The owned types behind a JSON column are not separately queryable,
+        // so ordering must not be demanded for them
+        Assert.DoesNotThrow(() => context.Entities.ToQueryString());
+    }
+
+    [Test]
+    public void RedundantJsonOrderBy_Throws()
+    {
+        using var context = new JsonRedundantContext(redundantOptions);
+
+        var exception = Assert.Throws<Exception>(
+            () => context.Entities
+                .OrderBy(_ => _.Meta.Rank)
+                .ToQueryString())!;
+
+        Assert.That(exception.Message, Does.Contain("JsonRedundantEntity"));
+        Assert.That(exception.Message, Does.Contain("OrderBy(Meta.Rank)"));
+    }
+
+    [Test]
+    public void DifferentJsonOrderBy_DoesNotThrow()
+    {
+        using var context = new JsonRedundantContext(redundantOptions);
+
+        // A different property of the same JSON column is not the configured ordering
+        Assert.DoesNotThrow(
+            () => context.Entities
+                .OrderBy(_ => _.Meta.Label)
+                .ToQueryString());
+    }
+
+    static readonly DbContextOptions<JsonRedundantContext> redundantOptions = BuildRedundantOptions();
+
+    static DbContextOptions<JsonRedundantContext> BuildRedundantOptions()
+    {
+        var builder = new DbContextOptionsBuilder<JsonRedundantContext>()
+            .UseSqlServer("Server=.;Database=Test;");
+        builder.UseDefaultOrderBy(throwOnRedundantOrderBy: true);
+        return builder.Options;
+    }
+
+    static JsonDbContext NewModelOnlyContext()
+    {
+        var builder = new DbContextOptionsBuilder<JsonDbContext>()
+            .UseSqlServer("Server=.;Database=Test;");
+        builder.UseDefaultOrderBy();
+        return new(builder.Options);
+    }
+}
+
+public class JsonProduct
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+    public JsonProductMetadata Metadata { get; set; } = new();
+    public List<JsonProductTag> Tags { get; set; } = [];
+}
+
+public class JsonProductMetadata
+{
+    public int Rank { get; set; }
+    public string Label { get; set; } = "";
+}
+
+public class JsonProductTag
+{
+    public string Value { get; set; } = "";
+}
+
+public class JsonArticle
+{
+    public int Id { get; set; }
+    public string Title { get; set; } = "";
+    public JsonArticleInfo Info { get; set; } = new();
+}
+
+public class JsonArticleInfo
+{
+    public JsonArticleAudit Audit { get; set; } = new();
+}
+
+public class JsonArticleAudit
+{
+    public DateTime Modified { get; set; }
+}
+
+public class JsonItem
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+    public string Category { get; set; } = "";
+    public JsonItemDetails Details { get; set; } = new();
+}
+
+public class JsonItemDetails
+{
+    public int Weight { get; set; }
+}
+
+public class JsonRedundantEntity
+{
+    public int Id { get; set; }
+    public JsonRedundantMeta Meta { get; set; } = new();
+}
+
+public class JsonRedundantMeta
+{
+    public int Rank { get; set; }
+    public string Label { get; set; } = "";
+}
+
+public class JsonRequiredEntity
+{
+    public int Id { get; set; }
+    public JsonRequiredMeta Meta { get; set; } = new();
+}
+
+public class JsonRequiredMeta
+{
+    public int Rank { get; set; }
+}
+
+class JsonRedundantContext(DbContextOptions<JsonRedundantContext> options) :
+    DbContext(options)
+{
+    public DbSet<JsonRedundantEntity> Entities => Set<JsonRedundantEntity>();
+
+    protected override void OnModelCreating(ModelBuilder model)
+    {
+        base.OnModelCreating(model);
+
+        var entity = model.Entity<JsonRedundantEntity>();
+        entity.OwnsOne(_ => _.Meta, _ => _.ToJson());
+        entity.OrderBy(_ => _.Meta.Rank);
+    }
+}
+
+class JsonRequiredContext(DbContextOptions<JsonRequiredContext> options) :
+    DbContext(options)
+{
+    public DbSet<JsonRequiredEntity> Entities => Set<JsonRequiredEntity>();
+
+    protected override void OnModelCreating(ModelBuilder model)
+    {
+        base.OnModelCreating(model);
+
+        var entity = model.Entity<JsonRequiredEntity>();
+        entity.OwnsOne(_ => _.Meta, _ => _.ToJson());
+        entity.OrderBy(_ => _.Meta.Rank);
+    }
+}
+
+public class JsonDbContext(DbContextOptions<JsonDbContext> options) :
+    DbContext(options)
+{
+    public DbSet<JsonProduct> Products => Set<JsonProduct>();
+    public DbSet<JsonArticle> Articles => Set<JsonArticle>();
+    public DbSet<JsonItem> Items => Set<JsonItem>();
+
+    protected override void OnModelCreating(ModelBuilder model)
+    {
+        base.OnModelCreating(model);
+
+        var product = model.Entity<JsonProduct>();
+        product.OwnsOne(_ => _.Metadata, _ => _.ToJson());
+        product.OwnsMany(_ => _.Tags, _ => _.ToJson());
+        product.OrderBy(_ => _.Metadata.Rank);
+
+        var article = model.Entity<JsonArticle>();
+        article.OwnsOne(
+            _ => _.Info,
+            owned =>
+            {
+                owned.ToJson();
+                owned.OwnsOne(_ => _.Audit);
+            });
+        article.OrderByDescending(_ => _.Info.Audit.Modified);
+
+        var item = model.Entity<JsonItem>();
+        item.OwnsOne(_ => _.Details, _ => _.ToJson());
+        item.Property(_ => _.Category).HasMaxLength(450);
+        item.OrderBy(_ => _.Category)
+            .ThenByDescending(_ => _.Details.Weight);
+    }
+}

--- a/src/Tests/Snippets.cs
+++ b/src/Tests/Snippets.cs
@@ -29,6 +29,24 @@ public class ConfigureOrderingExample : DbContext
     #endregion
 }
 
+public class JsonColumnExample : DbContext
+{
+    #region JsonColumnOrdering
+
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        builder.Entity<Order>()
+            .OwnsOne(_ => _.Metadata, _ => _.ToJson());
+
+        // Orders by a property of the JSON document rather than a column
+        builder.Entity<Order>()
+            .OrderByDescending(_ => _.Metadata.Priority)
+            .ThenBy(_ => _.Reference);
+    }
+
+    #endregion
+}
+
 public class RequireOrderingExample : DbContext
 {
     #region RequireOrdering
@@ -193,6 +211,18 @@ class Product
     public string Category { get; set; } = "";
     public string Name { get; set; } = "";
     public decimal Price { get; set; }
+}
+
+public class Order
+{
+    public int Id { get; set; }
+    public string Reference { get; set; } = "";
+    public OrderMetadata Metadata { get; set; } = new();
+}
+
+public class OrderMetadata
+{
+    public int Priority { get; set; }
 }
 
 #region InheritanceOrdering


### PR DESCRIPTION
`OrderBy`/`ThenBy` now accept a property path, so a property of a `ToJson()` mapped column can be used for default ordering.

```cs
builder.Entity<Order>()
    .OwnsOne(_ => _.Metadata, _ => _.ToJson());

builder.Entity<Order>()
    .OrderByDescending(_ => _.Metadata.Priority)
    .ThenBy(_ => _.Reference);
```

EF Core translates the path to a read of the JSON document:

```sql
ORDER BY CAST(JSON_VALUE([o].[Metadata], '$.Priority') AS int) DESC, [o].[Reference]
```

Paths of any depth work (`_ => _.Info.Audit.Modified` becomes `'$.Audit.Modified'`), and JSON properties mix with ordinary columns in the same chain. Everything else composes as before: the ordering is applied before `Skip`/`Take`/`First`, explicit ordering in a query still takes precedence, and inheritance, cross context conflict detection and redundant ordering detection all understand the dotted path.

## Implementation

- New `PropertyPath` resolves a member chain rooted at the lambda parameter. `OrderByClause` walks that chain instead of building a single `Expression.Property`.
- `ClauseMetadata` stores the dotted path, so derived type replay, conflict detection across contexts and `RedundantOrder` keep working unchanged.

## Two deliberate limits

**Indexes are skipped for JSON paths.** A JSON property is not a column of the entity's table, so there is nothing to name in `HasIndex`. This follows the existing string column behaviour: the index is skipped, the ordering still applies. A composite ordering is skipped whole when any one of its clauses reaches into JSON.

**JSON collections keep document order.** `Include(_ => _.Tags.OrderBy(...))` over a `ToJson()` collection throws `InvalidOperationException` on a tracking query; it only works under `AsNoTracking`. Auto applying ordering there would break queries that work today, so `IncludeOrderingApplicator` now leaves JSON mapped collections alone. Without that guard, a CLR type used both as a regular entity and as a JSON collection elsewhere would hit exactly that failure.

## Tests

Ten tests in `JsonColumnTests.cs` cover ordering, nesting, mixed chains, `Take`, index skipping, redundancy detection, `requireOrderingForAllEntities` against JSON owned types, and that a tracked `Include` over a JSON collection still works. Three Verify snapshots lock in the generated SQL.

Full suite passes in Release (139 tests), verified against SQL Server via LocalDb.

